### PR TITLE
enhance: changed NewConfigurationProvider interface to return error

### DIFF
--- a/chainedConfigurationProviderSource.go
+++ b/chainedConfigurationProviderSource.go
@@ -1,18 +1,22 @@
 package confignet
 
-import "github.com/maurik77/go-confignet/extensions"
+import (
+	"fmt"
+
+	"github.com/maurik77/go-confignet/extensions"
+)
 
 // ChainedConfigurationProviderSource is able to create ChainedConfigurationProvider starting from the provider settings
 type ChainedConfigurationProviderSource struct {
 }
 
 // NewConfigurationProvider creates ChainedConfigurationProvider starting from the provider settings
-func (providerSource *ChainedConfigurationProviderSource) NewConfigurationProvider(settings extensions.ProviderSettings) extensions.IConfigurationProvider {
+func (providerSource *ChainedConfigurationProviderSource) NewConfigurationProvider(settings extensions.ProviderSettings) (extensions.IConfigurationProvider, error) {
 	if settings.Name != providerSource.GetUniqueIdentifier() {
-		panic("ChainedConfigurationProviderSource: settings of configuration source " + settings.Name + " has been passed to the configuration source with unique identifier " + providerSource.GetUniqueIdentifier())
+		return nil, fmt.Errorf("ChainedConfigurationProviderSource: settings of configuration source " + settings.Name + " has been passed to the configuration source with unique identifier " + providerSource.GetUniqueIdentifier())
 	}
 
-	return &ChainedConfigurationProvider{}
+	return &ChainedConfigurationProvider{}, nil
 }
 
 // GetUniqueIdentifier returns the unique identifier of the configuration provider source. It will be use in the settings file

--- a/configurationBuilder.go
+++ b/configurationBuilder.go
@@ -68,7 +68,11 @@ func (conf *ConfigurationBuilder) ConfigureConfigurationProvidersFromSettings(se
 func configureConfigurationProvidersFromSettings(settings []extensions.ProviderSettings, configurationProvidersCollection extensions.IConfigurationProviderCollection) {
 	for _, providerSettings := range settings {
 		if configurationSource, ok := configurationSources[providerSettings.Name]; ok {
-			provider := configurationSource.NewConfigurationProvider(providerSettings)
+			provider, err := configurationSource.NewConfigurationProvider(providerSettings)
+			if err != nil {
+				log.Printf("ConfigurationBuilder: error in creating configuration provider: %s", err.Error())
+				continue
+			}
 
 			if decrypterSource, ok := decrypterSources[providerSettings.Decrypter.Name]; ok {
 				configurationProvidersCollection.AddWithEncrypter(provider, decrypterSource.NewConfigurationDecrypter(providerSettings.Decrypter))

--- a/extensions/configurationSource.go
+++ b/extensions/configurationSource.go
@@ -3,7 +3,7 @@ package extensions
 // IConfigurationSource is the interface of the configuration source
 type IConfigurationSource interface {
 	GetUniqueIdentifier() string
-	NewConfigurationProvider(settings ProviderSettings) IConfigurationProvider
+	NewConfigurationProvider(settings ProviderSettings) (IConfigurationProvider, error)
 }
 
 // Settings contains information usefull to configure the configuration providers

--- a/providers/cmdLineConfigurationProviderSource.go
+++ b/providers/cmdLineConfigurationProviderSource.go
@@ -1,15 +1,19 @@
 package providers
 
-import "github.com/maurik77/go-confignet/extensions"
+import (
+	"fmt"
+
+	"github.com/maurik77/go-confignet/extensions"
+)
 
 // CmdLineConfigurationProviderSource is able to create CmdLineConfigurationProvider starting from the provider settings
 type CmdLineConfigurationProviderSource struct {
 }
 
 // NewConfigurationProvider creates CmdLineConfigurationProvider starting from the provider settings
-func (providerSource *CmdLineConfigurationProviderSource) NewConfigurationProvider(settings extensions.ProviderSettings) extensions.IConfigurationProvider {
+func (providerSource *CmdLineConfigurationProviderSource) NewConfigurationProvider(settings extensions.ProviderSettings) (extensions.IConfigurationProvider, error) {
 	if settings.Name != providerSource.GetUniqueIdentifier() {
-		panic("CmdLineConfigurationProviderSource: settings of configuration source " + settings.Name + " has been passed to the configuration source with unique identifier " + providerSource.GetUniqueIdentifier())
+		return nil, fmt.Errorf("CmdLineConfigurationProviderSource: settings of configuration source " + settings.Name + " has been passed to the configuration source with unique identifier " + providerSource.GetUniqueIdentifier())
 	}
 
 	prefix := settings.GetPropertyValue("prefix", "").(string)
@@ -19,7 +23,7 @@ func (providerSource *CmdLineConfigurationProviderSource) NewConfigurationProvid
 	return &CmdLineConfigurationProvider{
 		Prefix:       prefix,
 		RemovePrefix: removePrefix,
-	}
+	}, nil
 }
 
 // GetUniqueIdentifier returns the unique identifier of the configuration provider source. It will be use in the settings file

--- a/providers/envConfigurationProviderSource.go
+++ b/providers/envConfigurationProviderSource.go
@@ -1,15 +1,19 @@
 package providers
 
-import "github.com/maurik77/go-confignet/extensions"
+import (
+	"fmt"
+
+	"github.com/maurik77/go-confignet/extensions"
+)
 
 // EnvConfigurationProviderSource is able to create EnvConfigurationProvider starting from the provider settings
 type EnvConfigurationProviderSource struct {
 }
 
 // NewConfigurationProvider creates EnvConfigurationProvider starting from the provider settings
-func (providerSource *EnvConfigurationProviderSource) NewConfigurationProvider(settings extensions.ProviderSettings) extensions.IConfigurationProvider {
+func (providerSource *EnvConfigurationProviderSource) NewConfigurationProvider(settings extensions.ProviderSettings) (extensions.IConfigurationProvider, error) {
 	if settings.Name != providerSource.GetUniqueIdentifier() {
-		panic("EnvConfigurationProviderSource: settings of configuration source " + settings.Name + " has been passed to the configuration source with unique identifier " + providerSource.GetUniqueIdentifier())
+		return nil, fmt.Errorf("EnvConfigurationProviderSource: settings of configuration source " + settings.Name + " has been passed to the configuration source with unique identifier " + providerSource.GetUniqueIdentifier())
 	}
 
 	prefix := settings.GetPropertyValue("prefix", "").(string)
@@ -18,7 +22,7 @@ func (providerSource *EnvConfigurationProviderSource) NewConfigurationProvider(s
 	return &EnvConfigurationProvider{
 		Prefix:       prefix,
 		RemovePrefix: removePrefix,
-	}
+	}, nil
 }
 
 // GetUniqueIdentifier returns the unique identifier of the configuration provider source. It will be use in the settings file

--- a/providers/jsonConfigurationProviderSource.go
+++ b/providers/jsonConfigurationProviderSource.go
@@ -1,22 +1,26 @@
 package providers
 
-import "github.com/maurik77/go-confignet/extensions"
+import (
+	"fmt"
+
+	"github.com/maurik77/go-confignet/extensions"
+)
 
 // JSONConfigurationProviderSource is able to create JSONConfigurationProvider starting from the provider settings
 type JSONConfigurationProviderSource struct {
 }
 
 // NewConfigurationProvider creates JSONConfigurationProvider starting from the provider settings
-func (providerSource *JSONConfigurationProviderSource) NewConfigurationProvider(settings extensions.ProviderSettings) extensions.IConfigurationProvider {
+func (providerSource *JSONConfigurationProviderSource) NewConfigurationProvider(settings extensions.ProviderSettings) (extensions.IConfigurationProvider, error) {
 	if settings.Name != providerSource.GetUniqueIdentifier() {
-		panic("JSONConfigurationProviderSource: settings of configuration source " + settings.Name + " has been passed to the configuration source with unique identifier " + providerSource.GetUniqueIdentifier())
+		return nil, fmt.Errorf("JSONConfigurationProviderSource: settings of configuration source " + settings.Name + " has been passed to the configuration source with unique identifier " + providerSource.GetUniqueIdentifier())
 	}
 
 	filePath := settings.GetPropertyValue("filePath", "").(string)
 
 	return &JSONConfigurationProvider{
 		FilePath: filePath,
-	}
+	}, nil
 }
 
 // GetUniqueIdentifier returns the unique identifier of the configuration provider source. It will be use in the settings file

--- a/providers/keyvaultConfigurationProviderSource.go
+++ b/providers/keyvaultConfigurationProviderSource.go
@@ -1,15 +1,19 @@
 package providers
 
-import "github.com/maurik77/go-confignet/extensions"
+import (
+	"fmt"
+
+	"github.com/maurik77/go-confignet/extensions"
+)
 
 // KeyvaultConfigurationProviderSource is able to create KeyvaultConfigurationProvider starting from the provider settings
 type KeyvaultConfigurationProviderSource struct {
 }
 
 // NewConfigurationProvider creates KeyvaultConfigurationProvider starting from the provider settings
-func (providerSource *KeyvaultConfigurationProviderSource) NewConfigurationProvider(settings extensions.ProviderSettings) extensions.IConfigurationProvider {
+func (providerSource *KeyvaultConfigurationProviderSource) NewConfigurationProvider(settings extensions.ProviderSettings) (extensions.IConfigurationProvider, error) {
 	if settings.Name != providerSource.GetUniqueIdentifier() {
-		panic("KeyvaultConfigurationProviderSource: settings of configuration source " + settings.Name + " has been passed to the configuration source with unique identifier " + providerSource.GetUniqueIdentifier())
+		return nil, fmt.Errorf("KeyvaultConfigurationProviderSource: settings of configuration source " + settings.Name + " has been passed to the configuration source with unique identifier " + providerSource.GetUniqueIdentifier())
 	}
 
 	prefix := settings.GetPropertyValue("prefix", "").(string)
@@ -26,7 +30,7 @@ func (providerSource *KeyvaultConfigurationProviderSource) NewConfigurationProvi
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
 		BaseURL:      baseURL,
-	}
+	}, nil
 }
 
 // GetUniqueIdentifier returns the unique identifier of the configuration provider source. It will be use in the settings file

--- a/providers/yamlConfigurationProviderSource.go
+++ b/providers/yamlConfigurationProviderSource.go
@@ -1,22 +1,26 @@
 package providers
 
-import "github.com/maurik77/go-confignet/extensions"
+import (
+	"fmt"
+
+	"github.com/maurik77/go-confignet/extensions"
+)
 
 // YamlConfigurationProviderSource is able to create YamlConfigurationProvider starting from the provider settings
 type YamlConfigurationProviderSource struct {
 }
 
 // NewConfigurationProvider creates YamlConfigurationProvider starting from the provider settings
-func (providerSource *YamlConfigurationProviderSource) NewConfigurationProvider(settings extensions.ProviderSettings) extensions.IConfigurationProvider {
+func (providerSource *YamlConfigurationProviderSource) NewConfigurationProvider(settings extensions.ProviderSettings) (extensions.IConfigurationProvider, error) {
 	if settings.Name != providerSource.GetUniqueIdentifier() {
-		panic("YamlConfigurationProviderSource: settings of configuration source " + settings.Name + " has been passed to the configuration source with unique identifier " + providerSource.GetUniqueIdentifier())
+		return nil, fmt.Errorf("YamlConfigurationProviderSource: settings of configuration source " + settings.Name + " has been passed to the configuration source with unique identifier " + providerSource.GetUniqueIdentifier())
 	}
 
 	filePath := settings.GetPropertyValue("filePath", "").(string)
 
 	return &YamlConfigurationProvider{
 		FilePath: filePath,
-	}
+	}, nil
 }
 
 // GetUniqueIdentifier returns the unique identifier of the configuration provider source. It will be use in the settings file


### PR DESCRIPTION
Changed the interface 

```go
type IConfigurationSource interface {
  ...
  NewConfigurationProvider(settings ProviderSettings) IConfigurationProvider
}
```

in 
```go
type IConfigurationSource interface {
  ...
  NewConfigurationProvider(settings ProviderSettings) (IConfigurationProvider, error)
}
```

to avoid `panic`.

Changed every invocation and handled the error by skipping the configuration in `configureConfigurationProvidersFromSettings` raising a warning 