### PR TITLE
Add float32 and float64 support to the configuration binder

### DIFF
--- a/internal/binder.go
+++ b/internal/binder.go
@@ -192,6 +192,14 @@ func fillField(field reflect.Value, value string, index int) {
 			} else {
 				log.Printf("Configuration:Unable to parse Bool the value %v", value)
 			}
+		case float32, float64:
+			if floatValue, err := strconv.ParseFloat(value, 64); err == nil {
+				if field.CanSet() {
+					field.SetFloat(floatValue)
+				}
+			} else {
+				log.Printf("Configuration:Unable to parse Float the value %v", value)
+			}
 		case time.Time:
 			if timeValue, err := time.Parse(time.RFC3339Nano, value); err == nil {
 				if field.CanSet() {

--- a/tests/app.json
+++ b/tests/app.json
@@ -8,6 +8,8 @@
       "PropertyInt8": 2,
       "PropertyInt16": 3,
       "PropertyInt64": 4,
+      "PropertyFloat32": 1.5,
+      "PropertyFloat64": 2.75,
       "PropertyBool": true,
       "Time": "2022-01-19T10:00:00Z",
       "ArrayStr": ["Test", "Test2"],

--- a/tests/configuration_test.go
+++ b/tests/configuration_test.go
@@ -37,6 +37,8 @@ func TestConfigurationProvidersWithEnvVars(t *testing.T) {
 	t.Setenv("config__Obj1__MapObj__99__PropertyString", "Created")
 	t.Setenv("config__Obj1__MapObj__99__PropertyInt", "88")
 	t.Setenv("config__Obj1__MapObj__99__PropertyBool", "true")
+	t.Setenv("config__Obj1__PropertyFloat32", "9.5")
+	t.Setenv("config__Obj1__PropertyFloat64", "12.25")
 
 	var confBuilder extensions.IConfigurationBuilder = &confignet.ConfigurationBuilder{}
 	confBuilder.AddDefaultConfigurationProviders()
@@ -54,6 +56,8 @@ func TestConfigurationProvidersWithEnvVars(t *testing.T) {
 	expected.Obj1.ArrayObj[0].PropertyString = "Modified"
 	expected.Obj1.ArrayObj = append(expected.Obj1.ArrayObj, subObjItem{PropertyString: "Created"})
 	expected.Obj1.MapObj[99] = subObjItem{PropertyString: "Created", PropertyInt: 88, PropertyBool: true}
+	expected.Obj1.PropertyFloat32 = 9.5
+	expected.Obj1.PropertyFloat64 = 12.25
 
 	timeCfg, _ := time.Parse(time.RFC3339Nano, "2022-01-21T10:00:00Z")
 	expected.Obj1.Time = timeCfg

--- a/tests/testUtils.go
+++ b/tests/testUtils.go
@@ -16,8 +16,10 @@ type subObj struct {
 	PropertyInt    int
 	PropertyInt8   int8
 	PropertyInt16  int16
-	PropertyInt64  int64
-	PropertyBool   bool
+	PropertyInt64   int64
+	PropertyFloat32 float32
+	PropertyFloat64 float64
+	PropertyBool    bool
 	Time           time.Time
 	ArrayStr       []string
 	ArrayInt       *[3]int
@@ -76,6 +78,16 @@ func validateSubObject(t *testing.T, expected subObj, result subObj) {
 		t.Fail()
 	}
 
+	if result.PropertyFloat32 != expected.PropertyFloat32 {
+		t.Logf("validateSubObject::error should be '%v', but got '%v'", expected.PropertyFloat32, result.PropertyFloat32)
+		t.Fail()
+	}
+
+	if result.PropertyFloat64 != expected.PropertyFloat64 {
+		t.Logf("validateSubObject::error should be '%v', but got '%v'", expected.PropertyFloat64, result.PropertyFloat64)
+		t.Fail()
+	}
+
 	if result.Time != expected.Time {
 		t.Logf("validateSubObject::error should be '%v', but got '%v'", expected.Time, result.Time)
 		t.Fail()
@@ -121,7 +133,9 @@ func getJSONExpectedValue() myConfig {
 			PropertyInt:    1,
 			PropertyInt8:   2,
 			PropertyInt16:  3,
-			PropertyInt64:  4,
+			PropertyInt64:   4,
+			PropertyFloat32: 1.5,
+			PropertyFloat64: 2.75,
 			PropertyBool:   true,
 			ArrayStr:       []string{"Test", "Test2"},
 			ArrayInt:       &[3]int{1, 2},


### PR DESCRIPTION
The reflection-based fillField function silently ignored float values. Added a float32/float64 case using strconv.ParseFloat with tests covering both JSON fixture loading and environment variable override paths.