### PR TITLE
Add custom logger support via extensions.Logger interface

### DIFF
--- a/chainedConfigurationProvider.go
+++ b/chainedConfigurationProvider.go
@@ -1,7 +1,6 @@
 package confignet
 
 import (
-	"log"
 	"strings"
 
 	"github.com/maurik77/go-confignet/extensions"
@@ -17,13 +16,13 @@ type ChainedConfigurationProvider struct {
 // Add adds the configuration provider to the inner collection
 func (provider *ChainedConfigurationProvider) Add(source extensions.IConfigurationProvider) {
 	provider.configurationProvidersInfo = append(provider.configurationProvidersInfo, extensions.ConfigurationProviderInfo{Provider: source})
-	log.Printf("ChainedConfigurationProvider:Added configuration provider '%T', Separator:'%v'\n", source, source.GetSeparator())
+	logger.Printf("ChainedConfigurationProvider:Added configuration provider '%T', Separator:'%v'\n", source, source.GetSeparator())
 }
 
 // AddWithEncrypter adds the configuration provider and the decrypter to the inner collection
 func (provider *ChainedConfigurationProvider) AddWithEncrypter(source extensions.IConfigurationProvider, decrypter extensions.IConfigurationDecrypter) {
 	provider.configurationProvidersInfo = append(provider.configurationProvidersInfo, extensions.ConfigurationProviderInfo{Provider: source, Decrypter: decrypter})
-	log.Printf("ConfigurationBuilder:Added configuration provider '%T', Separator:'%v'\n, Decrypter:'%T'", source, source.GetSeparator(), decrypter)
+	logger.Printf("ConfigurationBuilder:Added configuration provider '%T', Separator:'%v'\n, Decrypter:'%T'", source, source.GetSeparator(), decrypter)
 }
 
 // Load configuration from environment variables
@@ -51,7 +50,7 @@ func (provider *ChainedConfigurationProvider) Load(decrypter extensions.IConfigu
 			value, err := decrypter.Decrypt(values...)
 
 			if err != nil {
-				log.Printf("ChainedConfigurationProvider:Error calling decryption for key %v. %v", key, err)
+				logger.Printf("ChainedConfigurationProvider:Error calling decryption for key %v. %v", key, err)
 			} else {
 				provider.data[key] = value
 			}

--- a/configurationBuilder.go
+++ b/configurationBuilder.go
@@ -3,7 +3,6 @@ package confignet
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 
@@ -36,13 +35,13 @@ type ConfigurationBuilder struct {
 // Add adds the configuration provider to the inner collection
 func (conf *ConfigurationBuilder) Add(source extensions.IConfigurationProvider) {
 	conf.configurationProvidersInfo = append(conf.configurationProvidersInfo, extensions.ConfigurationProviderInfo{Provider: source})
-	log.Printf("ConfigurationBuilder:Added configuration provider '%T', Separator:'%v'\n", source, source.GetSeparator())
+	logger.Printf("ConfigurationBuilder:Added configuration provider '%T', Separator:'%v'\n", source, source.GetSeparator())
 }
 
 // AddWithEncrypter adds the configuration provider and the decrypter to the inner collection
 func (conf *ConfigurationBuilder) AddWithEncrypter(source extensions.IConfigurationProvider, decrypter extensions.IConfigurationDecrypter) {
 	conf.configurationProvidersInfo = append(conf.configurationProvidersInfo, extensions.ConfigurationProviderInfo{Provider: source, Decrypter: decrypter})
-	log.Printf("ConfigurationBuilder:Added configuration provider '%T', Separator:'%v'\n, Decrypter:'%T'", source, source.GetSeparator(), decrypter)
+	logger.Printf("ConfigurationBuilder:Added configuration provider '%T', Separator:'%v'\n, Decrypter:'%T'", source, source.GetSeparator(), decrypter)
 }
 
 // AddDefaultConfigurationProviders adds the default configuration providers
@@ -70,7 +69,7 @@ func configureConfigurationProvidersFromSettings(settings []extensions.ProviderS
 		if configurationSource, ok := configurationSources[providerSettings.Name]; ok {
 			provider, err := configurationSource.NewConfigurationProvider(providerSettings)
 			if err != nil {
-				log.Printf("ConfigurationBuilder: error in creating configuration provider: %s", err.Error())
+				logger.Printf("ConfigurationBuilder: error in creating configuration provider: %s", err.Error())
 				continue
 			}
 
@@ -85,7 +84,7 @@ func configureConfigurationProvidersFromSettings(settings []extensions.ProviderS
 			}
 
 		} else {
-			log.Printf("ConfigurationBuilder: unable to find configuration source with unique identifier '%v'", providerSettings.Name)
+			logger.Printf("ConfigurationBuilder: unable to find configuration source with unique identifier '%v'", providerSettings.Name)
 		}
 	}
 }
@@ -117,7 +116,7 @@ func (conf *ConfigurationBuilder) configureConfigurationProvidersFromJSONConfig(
 	err := internal.UnmarshalFromFile(jsonPath, &settings, json.Unmarshal)
 
 	if err != nil {
-		log.Printf("ConfigurationBuilder::configureConfigurationProvidersFromJSONConfig Error in UnmarshalFromFile %v", err)
+		logger.Printf("ConfigurationBuilder::configureConfigurationProvidersFromJSONConfig Error in UnmarshalFromFile %v", err)
 	}
 
 	conf.ConfigureConfigurationProvidersFromSettings(settings)
@@ -133,7 +132,7 @@ func (conf *ConfigurationBuilder) configureConfigurationProvidersFromYamlConfig(
 	err := internal.UnmarshalFromFile(yamlPath, &settings, yaml.Unmarshal)
 
 	if err != nil {
-		log.Printf("ConfigurationBuilder::configureConfigurationProvidersFromYamlConfig Error in UnmarshalFromFile %v", err)
+		logger.Printf("ConfigurationBuilder::configureConfigurationProvidersFromYamlConfig Error in UnmarshalFromFile %v", err)
 	}
 
 	conf.ConfigureConfigurationProvidersFromSettings(settings)

--- a/extensions/logger.go
+++ b/extensions/logger.go
@@ -1,0 +1,8 @@
+package extensions
+
+// Logger is the logging interface used by all confignet components.
+// Implement this interface to integrate your preferred logging library (zap, logrus, slog, etc.).
+// Register your implementation via confignet.SetLogger.
+type Logger interface {
+	Printf(format string, args ...interface{})
+}

--- a/internal/binder.go
+++ b/internal/binder.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"log"
 	"reflect"
 	"strconv"
 	"time"
@@ -13,10 +12,10 @@ func Unmarshal(target interface{}, value string, parts ...string) {
 }
 
 func fillObject(parent reflect.Value, value string, parts ...string) {
-	log.Printf("fillObject -> parts: %v, value: %v", parts, value)
+	Logger.Printf("fillObject -> parts: %v, value: %v", parts, value)
 
 	if parent.Kind() != reflect.Struct {
-		log.Printf("Configuration:Parent is not a valid struct %v. Parts %v", parent, parts)
+		Logger.Printf("Configuration:Parent is not a valid struct %v. Parts %v", parent, parts)
 		return
 	}
 
@@ -24,7 +23,7 @@ func fillObject(parent reflect.Value, value string, parts ...string) {
 	nestedField := parent.FieldByName(fieldName)
 
 	if !nestedField.IsValid() {
-		log.Printf("Configuration:Unable to find field %v in the object %v", fieldName, nestedField)
+		Logger.Printf("Configuration:Unable to find field %v in the object %v", fieldName, nestedField)
 		return
 	}
 
@@ -57,17 +56,17 @@ func checkValueOfPointer(field reflect.Value) reflect.Value {
 }
 
 func fillMap(nestedField reflect.Value, value string, parts ...string) {
-	log.Printf("fillMap -> parts: %v, value: %v", parts, value)
+	Logger.Printf("fillMap -> parts: %v, value: %v", parts, value)
 
 	mapKeyType := nestedField.Type().Key()
 	if mapKeyType.Kind() == reflect.Struct {
-		log.Printf("this version is not able to manage maps having struct as key")
+		Logger.Printf("this version is not able to manage maps having struct as key")
 		return
 	}
 
 	mapValueType := nestedField.Type().Elem()
 	key := parts[1]
-	log.Printf("  	mapKeyType: %v, mapValueType: %v, key: %v, value path: %v, value: %v", mapKeyType, mapValueType, key, parts[2:], value)
+	Logger.Printf("  	mapKeyType: %v, mapValueType: %v, key: %v, value path: %v, value: %v", mapKeyType, mapValueType, key, parts[2:], value)
 
 	if nestedField.IsNil() {
 		elemMap := reflect.MakeMap(reflect.MapOf(mapKeyType, mapValueType))
@@ -94,16 +93,16 @@ func fillMap(nestedField reflect.Value, value string, parts ...string) {
 }
 
 func fillArray(nestedField reflect.Value, value string, parts ...string) {
-	log.Printf("fillArray -> parts: %v, value: %v", parts, value)
+	Logger.Printf("fillArray -> parts: %v, value: %v", parts, value)
 
 	index, err := strconv.Atoi(parts[1])
 	if err != nil {
-		log.Printf("Configuration:Unable to parse index %v for path %v in the object %v", parts[1], parts, nestedField)
+		Logger.Printf("Configuration:Unable to parse index %v for path %v in the object %v", parts[1], parts, nestedField)
 		return
 	}
 
 	if index >= nestedField.Len() {
-		log.Printf("Configuration:Unable to assign value %v to the field %v with index %v because is out of range. (Array length  %v)", value, parts[0], index, nestedField.Len())
+		Logger.Printf("Configuration:Unable to assign value %v to the field %v with index %v because is out of range. (Array length  %v)", value, parts[0], index, nestedField.Len())
 		return
 	}
 
@@ -116,11 +115,11 @@ func fillArray(nestedField reflect.Value, value string, parts ...string) {
 }
 
 func fillSlice(nestedField reflect.Value, value string, parts ...string) {
-	log.Printf("fillSlice -> parts: %v, value: %v", parts, value)
+	Logger.Printf("fillSlice -> parts: %v, value: %v", parts, value)
 
 	index, err := strconv.Atoi(parts[1])
 	if err != nil {
-		log.Printf("Configuration:Unable to parse index %v for path %v in the object %v", parts[1], parts, nestedField)
+		Logger.Printf("Configuration:Unable to parse index %v for path %v in the object %v", parts[1], parts, nestedField)
 		return
 	}
 
@@ -147,7 +146,7 @@ func fillSlice(nestedField reflect.Value, value string, parts ...string) {
 }
 
 func fillField(field reflect.Value, value string, index int) {
-	log.Printf("fillField -> index: %v, value: %v, kind: %v", index, value, field.Kind())
+	Logger.Printf("fillField -> index: %v, value: %v, kind: %v", index, value, field.Kind())
 
 	switch field.Kind() {
 	case reflect.Array:
@@ -174,7 +173,7 @@ func fillField(field reflect.Value, value string, index int) {
 					field.SetInt(intValue)
 				}
 			} else {
-				log.Printf("Configuration:Unable to parse Int the value %v", value)
+				Logger.Printf("Configuration:Unable to parse Int the value %v", value)
 			}
 		case uint, uint8, uint16, uint32, uint64:
 			if uintValue, err := strconv.ParseUint(value, 10, 64); err == nil {
@@ -182,7 +181,7 @@ func fillField(field reflect.Value, value string, index int) {
 					field.SetUint(uintValue)
 				}
 			} else {
-				log.Printf("Configuration:Unable to parse Uint the value %v", value)
+				Logger.Printf("Configuration:Unable to parse Uint the value %v", value)
 			}
 		case bool:
 			if boolValue, err := strconv.ParseBool(value); err == nil {
@@ -190,7 +189,7 @@ func fillField(field reflect.Value, value string, index int) {
 					field.SetBool(boolValue)
 				}
 			} else {
-				log.Printf("Configuration:Unable to parse Bool the value %v", value)
+				Logger.Printf("Configuration:Unable to parse Bool the value %v", value)
 			}
 		case float32, float64:
 			if floatValue, err := strconv.ParseFloat(value, 64); err == nil {
@@ -198,7 +197,7 @@ func fillField(field reflect.Value, value string, index int) {
 					field.SetFloat(floatValue)
 				}
 			} else {
-				log.Printf("Configuration:Unable to parse Float the value %v", value)
+				Logger.Printf("Configuration:Unable to parse Float the value %v", value)
 			}
 		case time.Time:
 			if timeValue, err := time.Parse(time.RFC3339Nano, value); err == nil {
@@ -206,7 +205,7 @@ func fillField(field reflect.Value, value string, index int) {
 					field.Set(reflect.ValueOf(timeValue))
 				}
 			} else {
-				log.Printf("Configuration:Unable to parse Time (format: %v) the value %v", time.RFC3339Nano, value)
+				Logger.Printf("Configuration:Unable to parse Time (format: %v) the value %v", time.RFC3339Nano, value)
 			}
 		}
 	}

--- a/internal/logger.go
+++ b/internal/logger.go
@@ -1,0 +1,19 @@
+package internal
+
+import (
+	"log"
+
+	"github.com/maurik77/go-confignet/extensions"
+)
+
+type stdLogger struct{}
+
+func (stdLogger) Printf(format string, args ...interface{}) { log.Printf(format, args...) }
+
+// Logger is the active logger for the internal package. Use confignet.SetLogger to change it.
+var Logger extensions.Logger = stdLogger{}
+
+// SetLogger sets the logger used by the internal package.
+func SetLogger(l extensions.Logger) {
+	Logger = l
+}

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,34 @@
+package confignet
+
+import (
+	"log"
+
+	"github.com/maurik77/go-confignet/extensions"
+	"github.com/maurik77/go-confignet/internal"
+	"github.com/maurik77/go-confignet/providers"
+)
+
+type stdLogger struct{}
+
+func (stdLogger) Printf(format string, args ...interface{}) { log.Printf(format, args...) }
+
+// logger is the active logger for the confignet package.
+var logger extensions.Logger = stdLogger{}
+
+// SetLogger sets the logger used by all confignet components.
+// Call this before building any configuration.
+//
+// Example with logrus:
+//
+//	confignet.SetLogger(logrus.StandardLogger())
+//
+// Example with a custom logger:
+//
+//	confignet.SetLogger(myLogger)
+func SetLogger(l extensions.Logger) {
+	if l != nil {
+		logger = l
+		internal.SetLogger(l)
+		providers.SetLogger(l)
+	}
+}

--- a/providers/cmdLineConfigurationProvider.go
+++ b/providers/cmdLineConfigurationProvider.go
@@ -1,7 +1,6 @@
 package providers
 
 import (
-	"log"
 	"os"
 	"strings"
 
@@ -51,7 +50,7 @@ func (provider *CmdLineConfigurationProvider) Load(decrypter extensions.IConfigu
 			value, err = decrypter.Decrypt(value)
 
 			if err != nil {
-				log.Printf("CmdLineConfigurationProvider:Error calling decryption for key %v. %v", key, err)
+				logger.Printf("CmdLineConfigurationProvider:Error calling decryption for key %v. %v", key, err)
 			}
 		}
 

--- a/providers/envConfigurationProvider.go
+++ b/providers/envConfigurationProvider.go
@@ -1,7 +1,6 @@
 package providers
 
 import (
-	"log"
 	"os"
 	"strings"
 
@@ -37,7 +36,7 @@ func (provider *EnvConfigurationProvider) Load(decrypter extensions.IConfigurati
 			value, err = decrypter.Decrypt(value)
 
 			if err != nil {
-				log.Printf("EnvConfigurationProvider:Error calling decryption for key %v. %v", key, err)
+				logger.Printf("EnvConfigurationProvider:Error calling decryption for key %v. %v", key, err)
 			}
 		}
 

--- a/providers/jsonConfigurationProvider.go
+++ b/providers/jsonConfigurationProvider.go
@@ -2,7 +2,6 @@ package providers
 
 import (
 	"encoding/json"
-	"log"
 
 	"github.com/maurik77/go-confignet/extensions"
 	"github.com/maurik77/go-confignet/internal"
@@ -25,7 +24,7 @@ func (provider *JSONConfigurationProvider) Load(decrypter extensions.IConfigurat
 
 	err := internal.UnmarshalFromFile(provider.FilePath, &payload, json.Unmarshal)
 	if err != nil {
-		log.Println("JSONConfigurationProvider:Error during Unmarshal(): ", err)
+		logger.Printf("JSONConfigurationProvider:Error during Unmarshal(): %v", err)
 	}
 
 	provider.data = internal.LoadProperties(provider.GetSeparator(), payload)
@@ -37,7 +36,7 @@ func (provider *JSONConfigurationProvider) Load(decrypter extensions.IConfigurat
 			value, err = decrypter.Decrypt(value)
 
 			if err != nil {
-				log.Printf("JSONConfigurationProvider:Error calling decryption for key %v. %v", key, err)
+				logger.Printf("JSONConfigurationProvider:Error calling decryption for key %v. %v", key, err)
 			} else {
 				provider.data[key] = value
 			}

--- a/providers/keyvaultConfigurationProvider.go
+++ b/providers/keyvaultConfigurationProvider.go
@@ -3,7 +3,6 @@ package providers
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -30,13 +29,13 @@ func (provider *KeyVaultConfigurationProvider) Load(decrypter extensions.IConfig
 	cred, err := provider.getCredential()
 
 	if err != nil {
-		log.Println("KeyVaultConfigurationProvider:Unable to retrieve the token with the provided credentials")
+		logger.Printf("KeyVaultConfigurationProvider:Unable to retrieve the token with the provided credentials")
 	}
 
 	client, err := azsecrets.NewClient(provider.BaseURL, cred, nil)
 
 	if err != nil {
-		log.Println("KeyVaultConfigurationProvider:Unable to connect to keyvault with the provided credentials and base url", provider.BaseURL)
+		logger.Printf("KeyVaultConfigurationProvider:Unable to connect to keyvault with the provided credentials and base url %v", provider.BaseURL)
 	}
 
 	pager := client.ListSecrets(nil)
@@ -55,7 +54,7 @@ func (provider *KeyVaultConfigurationProvider) Load(decrypter extensions.IConfig
 
 			resp, err := client.GetSecret(context.Background(), key, nil)
 			if err != nil {
-				log.Printf("KeyVaultConfigurationProvider:Error retrieving key %v. %v", key, err)
+				logger.Printf("KeyVaultConfigurationProvider:Error retrieving key %v. %v", key, err)
 				continue
 			}
 
@@ -66,7 +65,7 @@ func (provider *KeyVaultConfigurationProvider) Load(decrypter extensions.IConfig
 				value, err = decrypter.Decrypt(value)
 
 				if err != nil {
-					log.Printf("KeyVaultConfigurationProvider:Error calling decryption for key %v. %v", key, err)
+					logger.Printf("KeyVaultConfigurationProvider:Error calling decryption for key %v. %v", key, err)
 				}
 			}
 

--- a/providers/logger.go
+++ b/providers/logger.go
@@ -1,0 +1,19 @@
+package providers
+
+import (
+	"log"
+
+	"github.com/maurik77/go-confignet/extensions"
+)
+
+type stdLogger struct{}
+
+func (stdLogger) Printf(format string, args ...interface{}) { log.Printf(format, args...) }
+
+// logger is the active logger for the providers package. Use confignet.SetLogger to change it.
+var logger extensions.Logger = stdLogger{}
+
+// SetLogger sets the logger used by the providers package.
+func SetLogger(l extensions.Logger) {
+	logger = l
+}

--- a/providers/yamlConfigurationProvider.go
+++ b/providers/yamlConfigurationProvider.go
@@ -1,8 +1,6 @@
 package providers
 
 import (
-	"log"
-
 	"github.com/maurik77/go-confignet/extensions"
 	"github.com/maurik77/go-confignet/internal"
 	"gopkg.in/yaml.v3"
@@ -26,7 +24,7 @@ func (provider *YamlConfigurationProvider) Load(decrypter extensions.IConfigurat
 	err := internal.UnmarshalFromFile(provider.FilePath, &payload, yaml.Unmarshal)
 
 	if err != nil {
-		log.Println("YamlConfigurationProvider:Error during Unmarshal(): ", err)
+		logger.Printf("YamlConfigurationProvider:Error during Unmarshal(): %v", err)
 	}
 
 	provider.data = internal.LoadProperties(provider.GetSeparator(), payload)
@@ -38,7 +36,7 @@ func (provider *YamlConfigurationProvider) Load(decrypter extensions.IConfigurat
 			value, err = decrypter.Decrypt(value)
 
 			if err != nil {
-				log.Printf("YamlConfigurationProvider:Error calling decryption for key %v. %v", key, err)
+				logger.Printf("YamlConfigurationProvider:Error calling decryption for key %v. %v", key, err)
 			} else {
 				provider.data[key] = value
 			}


### PR DESCRIPTION
Introduce extensions.Logger interface and confignet.SetLogger() so developers can plug in any logging library (logrus, zap, slog, etc.) instead of the default standard-library log package.