### PR TITLE
Fix golangci-lint warnings for ioutil and fmt.Errorf usage

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,29 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Go
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v ./...
+      working-directory: tests

--- a/chainedConfigurationProviderSource.go
+++ b/chainedConfigurationProviderSource.go
@@ -18,7 +18,7 @@ type ChainedConfigurationProviderSource struct {
 // NewConfigurationProvider creates ChainedConfigurationProvider starting from the provider settings
 func (providerSource *ChainedConfigurationProviderSource) NewConfigurationProvider(settings extensions.ProviderSettings) (extensions.IConfigurationProvider, error) {
 	if settings.Name != providerSource.GetUniqueIdentifier() {
-		return nil, fmt.Errorf("ChainedConfigurationProviderSource: settings of configuration source " + settings.Name + " has been passed to the configuration source with unique identifier " + providerSource.GetUniqueIdentifier())
+		return nil, fmt.Errorf("ChainedConfigurationProviderSource: settings of configuration source %s has been passed to the configuration source with unique identifier %s", settings.Name, providerSource.GetUniqueIdentifier())
 	}
 
 	return &ChainedConfigurationProvider{}, nil

--- a/internal/aes.go
+++ b/internal/aes.go
@@ -7,7 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 )
 
 // EncryptBytesToBase64 encrypts string with secret
@@ -70,7 +70,7 @@ func base64ToBytes(encryptedString string) ([]byte, error) {
 	src := []byte(encryptedString)
 	r := bytes.NewReader(src)
 	input := base64.NewDecoder(base64.StdEncoding, r)
-	data, err := ioutil.ReadAll(input)
+	data, err := io.ReadAll(input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/serializer.go
+++ b/internal/serializer.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 )
 
@@ -14,7 +13,7 @@ func UnmarshalFromFile(path string, target interface{}, unmarshal func(in []byte
 		return fmt.Errorf("UnmarshalFromFile:File not found %v", path)
 	}
 
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 
 	if err != nil {
 		return fmt.Errorf("UnmarshalFromFile:Error when opening file '%v': '%v'", path, err)
@@ -38,7 +37,7 @@ func MarshalToFile(path string, source interface{}, marshal func(v interface{}) 
 	}
 
 	// #nosec G306
-	err = ioutil.WriteFile(path, data, 0644)
+	err = os.WriteFile(path, data, 0644)
 
 	return err
 }

--- a/providers/cmdLineConfigurationProviderSource.go
+++ b/providers/cmdLineConfigurationProviderSource.go
@@ -18,7 +18,7 @@ type CmdLineConfigurationProviderSource struct {
 // NewConfigurationProvider creates CmdLineConfigurationProvider starting from the provider settings
 func (providerSource *CmdLineConfigurationProviderSource) NewConfigurationProvider(settings extensions.ProviderSettings) (extensions.IConfigurationProvider, error) {
 	if settings.Name != providerSource.GetUniqueIdentifier() {
-		return nil, fmt.Errorf("CmdLineConfigurationProviderSource: settings of configuration source " + settings.Name + " has been passed to the configuration source with unique identifier " + providerSource.GetUniqueIdentifier())
+		return nil, fmt.Errorf("CmdLineConfigurationProviderSource: settings of configuration source %s has been passed to the configuration source with unique identifier %s", settings.Name, providerSource.GetUniqueIdentifier())
 	}
 
 	prefix := settings.GetPropertyValue("prefix", "").(string)

--- a/providers/envConfigurationProviderSource.go
+++ b/providers/envConfigurationProviderSource.go
@@ -18,7 +18,7 @@ type EnvConfigurationProviderSource struct {
 // NewConfigurationProvider creates EnvConfigurationProvider starting from the provider settings
 func (providerSource *EnvConfigurationProviderSource) NewConfigurationProvider(settings extensions.ProviderSettings) (extensions.IConfigurationProvider, error) {
 	if settings.Name != providerSource.GetUniqueIdentifier() {
-		return nil, fmt.Errorf("EnvConfigurationProviderSource: settings of configuration source " + settings.Name + " has been passed to the configuration source with unique identifier " + providerSource.GetUniqueIdentifier())
+		return nil, fmt.Errorf("EnvConfigurationProviderSource: settings of configuration source %s has been passed to the configuration source with unique identifier %s", settings.Name, providerSource.GetUniqueIdentifier())
 	}
 
 	prefix := settings.GetPropertyValue("prefix", "").(string)

--- a/providers/jsonConfigurationProviderSource.go
+++ b/providers/jsonConfigurationProviderSource.go
@@ -18,7 +18,7 @@ type JSONConfigurationProviderSource struct {
 // NewConfigurationProvider creates JSONConfigurationProvider starting from the provider settings
 func (providerSource *JSONConfigurationProviderSource) NewConfigurationProvider(settings extensions.ProviderSettings) (extensions.IConfigurationProvider, error) {
 	if settings.Name != providerSource.GetUniqueIdentifier() {
-		return nil, fmt.Errorf("JSONConfigurationProviderSource: settings of configuration source " + settings.Name + " has been passed to the configuration source with unique identifier " + providerSource.GetUniqueIdentifier())
+		return nil, fmt.Errorf("JSONConfigurationProviderSource: settings of configuration source %s has been passed to the configuration source with unique identifier %s", settings.Name, providerSource.GetUniqueIdentifier())
 	}
 
 	filePath := settings.GetPropertyValue("filePath", "").(string)

--- a/providers/keyvaultConfigurationProviderSource.go
+++ b/providers/keyvaultConfigurationProviderSource.go
@@ -18,7 +18,7 @@ type KeyVaultConfigurationProviderSource struct {
 // NewConfigurationProvider creates KeyVaultConfigurationProvider starting from the provider settings
 func (providerSource *KeyVaultConfigurationProviderSource) NewConfigurationProvider(settings extensions.ProviderSettings) (extensions.IConfigurationProvider, error) {
 	if settings.Name != providerSource.GetUniqueIdentifier() {
-		return nil, fmt.Errorf("KeyVaultConfigurationProviderSource: settings of configuration source " + settings.Name + " has been passed to the configuration source with unique identifier " + providerSource.GetUniqueIdentifier())
+		return nil, fmt.Errorf("KeyVaultConfigurationProviderSource: settings of configuration source %s has been passed to the configuration source with unique identifier %s", settings.Name, providerSource.GetUniqueIdentifier())
 	}
 
 	prefix := settings.GetPropertyValue("prefix", "").(string)

--- a/providers/yamlConfigurationProviderSource.go
+++ b/providers/yamlConfigurationProviderSource.go
@@ -18,7 +18,7 @@ type YamlConfigurationProviderSource struct {
 // NewConfigurationProvider creates YamlConfigurationProvider starting from the provider settings
 func (providerSource *YamlConfigurationProviderSource) NewConfigurationProvider(settings extensions.ProviderSettings) (extensions.IConfigurationProvider, error) {
 	if settings.Name != providerSource.GetUniqueIdentifier() {
-		return nil, fmt.Errorf("YamlConfigurationProviderSource: settings of configuration source " + settings.Name + " has been passed to the configuration source with unique identifier " + providerSource.GetUniqueIdentifier())
+		return nil, fmt.Errorf("YamlConfigurationProviderSource: settings of configuration source %s has been passed to the configuration source with unique identifier %s", settings.Name, providerSource.GetUniqueIdentifier())
 	}
 
 	filePath := settings.GetPropertyValue("filePath", "").(string)


### PR DESCRIPTION
…ngs)

- Replace io/ioutil with io.ReadAll and os.ReadFile/WriteFile (SA1019)
- Replace fmt.Errorf string concatenation with %s format verbs in all provider sources (govet: non-constant format string)