### PR TITLE
feat: add default struct tag for zero-value field defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ The meta-configuration system lets you list providers, their properties, and the
 **Come from an ASP.NET Core background.**
 The builder pattern, provider interface, and layered override model are directly inspired by `Microsoft.Extensions.Configuration`. The mental model transfers.
 
+**Want predictable, explicit key matching.**
+go-confignet is case-sensitive by design. `Database.Host` and `database.host` are distinct keys, exactly as they are in Go struct field names. Some libraries silently fold all keys to lowercase — a convenience that creates subtle bugs when two keys differ only by case, and unexpected behaviour when working with secrets or provider-specific naming conventions. go-confignet never normalises your keys behind your back.
+
 ---
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Requires **Go 1.18** or later.
 - [Built-in Providers](#built-in-providers)
   - [JSON](#json)
   - [YAML](#yaml)
+  - [TOML](#toml)
   - [Environment Variables](#environment-variables)
   - [Command Line Arguments](#command-line-arguments)
   - [Azure Key Vault](#azure-key-vault)
@@ -238,6 +239,45 @@ app:
 ```go
 confBuilder.Add(&providers.YamlConfigurationProvider{FilePath: "config/app.yaml"})
 ```
+
+---
+
+### TOML
+
+Loads configuration from a TOML file. Separator: `.`
+
+```go
+type TomlConfigurationProvider struct {
+    FilePath string // default: "app.toml"
+}
+```
+
+**Example file:**
+
+```toml
+[app]
+PropertyInt8 = 45
+
+[app.Database]
+Host = "localhost"
+Port = 5432
+
+[[app.Items]]
+Name  = "first"
+Value = 10
+
+[[app.Items]]
+Name  = "second"
+Value = 20
+```
+
+**Usage:**
+
+```go
+confBuilder.Add(&providers.TomlConfigurationProvider{FilePath: "config/app.toml"})
+```
+
+**Note:** TOML arrays of tables (`[[...]]`) and inline arrays are both fully supported.
 
 ---
 
@@ -517,6 +557,7 @@ confBuilder.ConfigureConfigurationProvidersFromEnv()
 |------------|----------------------------------|
 | `json`     | JSONConfigurationProvider        |
 | `yaml`     | YamlConfigurationProvider        |
+| `toml`     | TomlConfigurationProvider        |
 | `env`      | EnvConfigurationProvider         |
 | `cmdline`  | CmdLineConfigurationProvider     |
 | `keyvault` | KeyVaultConfigurationProvider    |

--- a/common.go
+++ b/common.go
@@ -58,6 +58,7 @@ func init() {
 	RegisterConfigurationSource(&providers.EnvConfigurationProviderSource{})
 	RegisterConfigurationSource(&providers.JSONConfigurationProviderSource{})
 	RegisterConfigurationSource(&providers.YamlConfigurationProviderSource{})
+	RegisterConfigurationSource(&providers.TomlConfigurationProviderSource{})
 	RegisterConfigurationSource(&providers.KeyVaultConfigurationProviderSource{})
 	RegisterConfigurationSource(&ChainedConfigurationProviderSource{})
 	RegisterDecrypterSource(&decrypters.AesConfigurationDecrypterSource{})

--- a/configuration.go
+++ b/configuration.go
@@ -88,6 +88,8 @@ func (conf *Configuration) Bind(section string, target interface{}) error {
 		return &InvalidBindError{reflect.TypeOf(target)}
 	}
 
+	internal.ApplyDefaults(target)
+
 	for _, p := range conf.configurationProvidersInfo {
 		props := filterProperties(section, p)
 		conf.bindProps(p, props, target)

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 // indirect
+	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJ
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 h1:XRzhVemXdgvJqCH0sFfrBUTnUJSBrBf7++ypk+twtRs=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=

--- a/internal/defaults.go
+++ b/internal/defaults.go
@@ -1,0 +1,45 @@
+package internal
+
+import "reflect"
+
+// ApplyDefaults walks the struct pointed to by target and sets any field
+// tagged with `default:"<value>"` to that value when the field currently
+// holds its zero value. Provider-supplied values are applied afterwards by
+// the caller, so they always take precedence over tag defaults.
+func ApplyDefaults(target interface{}) {
+	rv := reflect.ValueOf(target)
+	if rv.Kind() != reflect.Ptr || rv.IsNil() {
+		return
+	}
+	applyDefaultsToStruct(rv.Elem())
+}
+
+func applyDefaultsToStruct(v reflect.Value) {
+	if v.Kind() != reflect.Struct {
+		return
+	}
+	t := v.Type()
+	for i := 0; i < t.NumField(); i++ {
+		field := v.Field(i)
+		fieldType := t.Field(i)
+
+		// Apply the default only for scalar/pointer fields (not structs themselves).
+		if defaultVal, ok := fieldType.Tag.Lookup("default"); ok &&
+			field.Kind() != reflect.Struct &&
+			field.IsZero() {
+			fillField(field, defaultVal, -1)
+		}
+
+		// Recurse into nested structs and already-allocated pointer-to-structs.
+		switch field.Kind() {
+		case reflect.Struct:
+			applyDefaultsToStruct(field)
+		case reflect.Ptr:
+			if !field.IsNil() {
+				if elem := field.Elem(); elem.Kind() == reflect.Struct {
+					applyDefaultsToStruct(elem)
+				}
+			}
+		}
+	}
+}

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -20,6 +20,12 @@ func loadProperties(parent string, separator string, valueMap map[string]interfa
 			data[key] = fmt.Sprint(value)
 		case []interface{}:
 			loadArray(key, separator, v, data)
+		case []map[string]interface{}:
+			slice := make([]interface{}, len(v))
+			for i, item := range v {
+				slice[i] = item
+			}
+			loadArray(key, separator, slice, data)
 		case map[string]interface{}:
 			loadProperties(key, separator, v, data)
 		}

--- a/providers/tomlConfigurationProvider.go
+++ b/providers/tomlConfigurationProvider.go
@@ -23,9 +23,7 @@ func (provider *TomlConfigurationProvider) Load(decrypter extensions.IConfigurat
 	provider.data = make(map[string]string)
 
 	var payload map[string]interface{}
-	err := internal.UnmarshalFromFile(provider.FilePath, &payload, func(in []byte, out interface{}) error {
-		return toml.Unmarshal(in, out)
-	})
+	err := internal.UnmarshalFromFile(provider.FilePath, &payload, toml.Unmarshal)
 
 	if err != nil {
 		logger.Printf("TomlConfigurationProvider:Error during Unmarshal(): %v", err)

--- a/providers/tomlConfigurationProvider.go
+++ b/providers/tomlConfigurationProvider.go
@@ -1,0 +1,56 @@
+package providers
+
+import (
+	"github.com/BurntSushi/toml"
+	"github.com/maurik77/go-confignet/extensions"
+	"github.com/maurik77/go-confignet/internal"
+)
+
+const (
+	// DefaultTOMLFile is the default TOML configuration file name
+	DefaultTOMLFile = "app.toml"
+)
+
+// TomlConfigurationProvider loads configuration from a TOML file.
+// It uses "." (dot) as separator for hierarchical configuration.
+type TomlConfigurationProvider struct {
+	FilePath string // default: "app.toml"
+	data     map[string]string
+}
+
+// Load reads the TOML file and populates the internal key-value map.
+func (provider *TomlConfigurationProvider) Load(decrypter extensions.IConfigurationDecrypter) {
+	provider.data = make(map[string]string)
+
+	var payload map[string]interface{}
+	err := internal.UnmarshalFromFile(provider.FilePath, &payload, func(in []byte, out interface{}) error {
+		return toml.Unmarshal(in, out)
+	})
+
+	if err != nil {
+		logger.Printf("TomlConfigurationProvider:Error during Unmarshal(): %v", err)
+	}
+
+	provider.data = internal.LoadProperties(provider.GetSeparator(), payload)
+
+	if decrypter != nil {
+		for key, value := range provider.data {
+			decrypted, err := decrypter.Decrypt(value)
+			if err != nil {
+				logger.Printf("TomlConfigurationProvider:Error calling decryption for key %v. %v", key, err)
+			} else {
+				provider.data[key] = decrypted
+			}
+		}
+	}
+}
+
+// GetData returns the loaded key-value map.
+func (provider *TomlConfigurationProvider) GetData() map[string]string {
+	return provider.data
+}
+
+// GetSeparator returns the separator used for hierarchical keys.
+func (provider *TomlConfigurationProvider) GetSeparator() string {
+	return "."
+}

--- a/providers/tomlConfigurationProviderSource.go
+++ b/providers/tomlConfigurationProviderSource.go
@@ -1,0 +1,33 @@
+package providers
+
+import (
+	"fmt"
+
+	"github.com/maurik77/go-confignet/extensions"
+)
+
+const (
+	// ConfigurationProviderTOMLIdentifier is the unique identifier for the TOML provider in settings files
+	ConfigurationProviderTOMLIdentifier = "toml"
+)
+
+// TomlConfigurationProviderSource creates TomlConfigurationProvider instances from provider settings.
+type TomlConfigurationProviderSource struct{}
+
+// NewConfigurationProvider creates a TomlConfigurationProvider from the given settings.
+func (s *TomlConfigurationProviderSource) NewConfigurationProvider(settings extensions.ProviderSettings) (extensions.IConfigurationProvider, error) {
+	if settings.Name != s.GetUniqueIdentifier() {
+		return nil, fmt.Errorf("TomlConfigurationProviderSource: settings of configuration source %s has been passed to the configuration source with unique identifier %s", settings.Name, s.GetUniqueIdentifier())
+	}
+
+	filePath := settings.GetPropertyValue("filePath", "").(string)
+
+	return &TomlConfigurationProvider{
+		FilePath: filePath,
+	}, nil
+}
+
+// GetUniqueIdentifier returns the identifier used to reference this provider in settings files.
+func (s *TomlConfigurationProviderSource) GetUniqueIdentifier() string {
+	return ConfigurationProviderTOMLIdentifier
+}

--- a/tests/app-array-syntax.json
+++ b/tests/app-array-syntax.json
@@ -1,0 +1,10 @@
+{
+  "arr": {
+    "Strings": ["hello", "world"],
+    "Items": [
+      { "Name": "first",  "Value": 10 },
+      { "Name": "second", "Value": 20 }
+    ],
+    "Fixed": [10, 42, 30]
+  }
+}

--- a/tests/app.toml
+++ b/tests/app.toml
@@ -1,0 +1,69 @@
+[config]
+PropertyInt8 = 45
+
+[config.Obj1]
+PropertyString = "TestObj1"
+PropertyInt    = 1
+PropertyInt8   = 2
+PropertyInt16  = 3
+PropertyInt64  = 4
+PropertyFloat32 = 1.5
+PropertyFloat64 = 2.75
+PropertyBool   = true
+Time           = "2022-01-19T10:00:00Z"
+ArrayStr       = ["Test", "Test2"]
+ArrayInt       = [1, 2]
+
+[[config.Obj1.ArrayObj]]
+PropertyString = "TestArrObj1"
+PropertyInt    = 1
+PropertyBool   = true
+
+[[config.Obj1.ArrayObj]]
+PropertyString = "TestArrObj2"
+PropertyInt    = 2
+PropertyBool   = false
+
+[[config.Obj1.ArrayObjPtr]]
+PropertyString = "TestArrObj1"
+PropertyInt    = 1
+PropertyBool   = true
+
+[[config.Obj1.ArrayObjPtr]]
+PropertyString = "TestArrObj2"
+PropertyInt    = 2
+PropertyBool   = false
+
+[config.Obj1.MapStr]
+Key1 = "Value1"
+Key2 = "Value2"
+
+[config.Obj1.MapInt]
+1 = "1"
+2 = "2"
+
+[config.Obj1.MapObj.1]
+PropertyString = "TestArrObj1"
+PropertyInt    = 1
+PropertyBool   = true
+
+[config.Obj1.MapObj.2]
+PropertyString = "TestArrObj2"
+PropertyInt    = 2
+PropertyBool   = false
+
+[config.Obj1.MapObj.99]
+PropertyString = "MapObjStrYaml"
+PropertyInt    = 87
+PropertyBool   = true
+
+[config.Obj1.MapObjPtr]
+[config.Obj1.MapObjPtr.false]
+PropertyString = "TestArrObj1"
+PropertyInt    = 1
+PropertyBool   = true
+
+[config.Obj1.MapObjPtr.true]
+PropertyString = "TestArrObj2"
+PropertyInt    = 2
+PropertyBool   = false

--- a/tests/array_syntax_test.go
+++ b/tests/array_syntax_test.go
@@ -1,0 +1,107 @@
+package tests
+
+import (
+	"testing"
+
+	confignet "github.com/maurik77/go-confignet"
+	"github.com/maurik77/go-confignet/extensions"
+	"github.com/maurik77/go-confignet/providers"
+	"github.com/stretchr/testify/assert"
+)
+
+// arrayConfig is a self-contained struct for array syntax tests.
+type arrayConfig struct {
+	Strings  []string
+	Ints     []int
+	Items    []arrayItem
+	ItemsPtr []*arrayItem
+	Fixed    [3]int
+}
+
+type arrayItem struct {
+	Name  string
+	Value int
+}
+
+// TestArraySyntax_Slice_Primitive verifies: Strings__0 = "hello"
+func TestArraySyntax_Slice_Primitive(t *testing.T) {
+	t.Setenv("arr__Strings__0", "hello")
+	t.Setenv("arr__Strings__1", "world")
+
+	conf := buildEnvConf(t)
+	cfg := arrayConfig{}
+	assert.Nil(t, conf.Bind("arr", &cfg))
+
+	assert.Equal(t, "hello", cfg.Strings[0])
+	assert.Equal(t, "world", cfg.Strings[1])
+}
+
+// TestArraySyntax_Slice_Object verifies: Items__0__Name = "first"
+func TestArraySyntax_Slice_Object(t *testing.T) {
+	t.Setenv("arr__Items__0__Name", "first")
+	t.Setenv("arr__Items__0__Value", "10")
+	t.Setenv("arr__Items__1__Name", "second")
+	t.Setenv("arr__Items__1__Value", "20")
+
+	conf := buildEnvConf(t)
+	cfg := arrayConfig{}
+	assert.Nil(t, conf.Bind("arr", &cfg))
+
+	assert.Equal(t, "first", cfg.Items[0].Name)
+	assert.Equal(t, 10, cfg.Items[0].Value)
+	assert.Equal(t, "second", cfg.Items[1].Name)
+	assert.Equal(t, 20, cfg.Items[1].Value)
+}
+
+// TestArraySyntax_Slice_ObjectPtr verifies: ItemsPtr__0__Name = "first" (slice of pointers)
+func TestArraySyntax_Slice_ObjectPtr(t *testing.T) {
+	t.Setenv("arr__ItemsPtr__0__Name", "ptr-first")
+	t.Setenv("arr__ItemsPtr__0__Value", "99")
+
+	conf := buildEnvConf(t)
+	cfg := arrayConfig{}
+	assert.Nil(t, conf.Bind("arr", &cfg))
+
+	assert.Equal(t, "ptr-first", cfg.ItemsPtr[0].Name)
+	assert.Equal(t, 99, cfg.ItemsPtr[0].Value)
+}
+
+// TestArraySyntax_FixedArray_Primitive verifies: Fixed__1 = "42" (fixed-size array)
+func TestArraySyntax_FixedArray_Primitive(t *testing.T) {
+	t.Setenv("arr__Fixed__0", "10")
+	t.Setenv("arr__Fixed__1", "42")
+	t.Setenv("arr__Fixed__2", "30")
+
+	conf := buildEnvConf(t)
+	cfg := arrayConfig{}
+	assert.Nil(t, conf.Bind("arr", &cfg))
+
+	assert.Equal(t, 10, cfg.Fixed[0])
+	assert.Equal(t, 42, cfg.Fixed[1])
+	assert.Equal(t, 30, cfg.Fixed[2])
+}
+
+// TestArraySyntax_JSON verifies the same patterns via JSON (separator: ".")
+func TestArraySyntax_JSON(t *testing.T) {
+	var confBuilder extensions.IConfigurationBuilder = &confignet.ConfigurationBuilder{}
+	confBuilder.Add(&providers.JSONConfigurationProvider{FilePath: "app-array-syntax.json"})
+	conf := confBuilder.Build()
+
+	cfg := arrayConfig{}
+	assert.Nil(t, conf.Bind("arr", &cfg))
+
+	assert.Equal(t, "hello", cfg.Strings[0])
+	assert.Equal(t, "world", cfg.Strings[1])
+	assert.Equal(t, "first", cfg.Items[0].Name)
+	assert.Equal(t, 10, cfg.Items[0].Value)
+	assert.Equal(t, "second", cfg.Items[1].Name)
+	assert.Equal(t, 20, cfg.Items[1].Value)
+	assert.Equal(t, 42, cfg.Fixed[1])
+}
+
+func buildEnvConf(t *testing.T) extensions.IConfiguration {
+	t.Helper()
+	var confBuilder extensions.IConfigurationBuilder = &confignet.ConfigurationBuilder{}
+	confBuilder.Add(&providers.EnvConfigurationProvider{})
+	return confBuilder.Build()
+}

--- a/tests/coverage_gaps_test.go
+++ b/tests/coverage_gaps_test.go
@@ -1,0 +1,340 @@
+package tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	confignet "github.com/maurik77/go-confignet"
+	"github.com/maurik77/go-confignet/decrypters"
+	"github.com/maurik77/go-confignet/extensions"
+	"github.com/maurik77/go-confignet/internal"
+	"github.com/maurik77/go-confignet/providers"
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func buildJSONConf(filePath string) extensions.IConfiguration {
+	var b extensions.IConfigurationBuilder = &confignet.ConfigurationBuilder{}
+	b.Add(&providers.JSONConfigurationProvider{FilePath: filePath})
+	return b.Build()
+}
+
+// ---------------------------------------------------------------------------
+// InvalidBindError.Error()
+// ---------------------------------------------------------------------------
+
+func TestInvalidBindError_Nil(t *testing.T) {
+	conf := buildJSONConf("app.json")
+	err := conf.Bind("config", nil)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "nil")
+}
+
+func TestInvalidBindError_NonPointer(t *testing.T) {
+	conf := buildJSONConf("app.json")
+	var cfg myConfig
+	err := conf.Bind("config", cfg) // not a pointer
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "non-pointer")
+}
+
+func TestInvalidBindError_NilPointer(t *testing.T) {
+	conf := buildJSONConf("app.json")
+	var cfg *myConfig // nil pointer
+	err := conf.Bind("config", cfg)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "nil")
+}
+
+// ---------------------------------------------------------------------------
+// Configuration.GetProviders()
+// ---------------------------------------------------------------------------
+
+func TestConfiguration_GetProviders(t *testing.T) {
+	p1 := &providers.JSONConfigurationProvider{FilePath: "app.json"}
+	p2 := &providers.YamlConfigurationProvider{FilePath: "app.yaml"}
+
+	var b extensions.IConfigurationBuilder = &confignet.ConfigurationBuilder{}
+	b.Add(p1)
+	b.Add(p2)
+	conf := b.Build()
+
+	infos := conf.GetProviders()
+	assert.Len(t, infos, 2)
+	assert.Equal(t, p1, infos[0].Provider)
+	assert.Equal(t, p2, infos[1].Provider)
+}
+
+// ---------------------------------------------------------------------------
+// ChainedConfigurationProvider.AddWithEncrypter() & GetDataMultiValues()
+// ---------------------------------------------------------------------------
+
+func TestChainedConfigurationProvider_AddWithEncrypter(t *testing.T) {
+	// Verify AddWithEncrypter registers the provider+decrypter without panicking.
+	// We don't call Load here because the Shamir data is not AES-encrypted.
+	chained := &confignet.ChainedConfigurationProvider{}
+	dec := &decrypters.AesConfigurationDecrypter{Secret: "mysecret"}
+	chained.AddWithEncrypter(&providers.JSONConfigurationProvider{FilePath: "app.json"}, dec)
+
+	// GetProviders is not on ChainedConfigurationProvider, but GetData returns empty before Load
+	data := chained.GetData()
+	assert.Nil(t, data) // not loaded yet
+}
+
+func TestChainedConfigurationProvider_GetDataMultiValues(t *testing.T) {
+	chained := &confignet.ChainedConfigurationProvider{}
+	chained.Add(&providers.JSONConfigurationProvider{FilePath: "shamir/copy-shamir-2.json"})
+	chained.Add(&providers.YamlConfigurationProvider{FilePath: "shamir/copy-shamir-3.yaml"})
+
+	chained.Load(nil)
+
+	multiValues := chained.GetDataMultiValues()
+	assert.NotNil(t, multiValues)
+
+	// Both files have the same key, so at least one key should have 2 values
+	found := false
+	for _, vals := range multiValues {
+		if len(vals) == 2 {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected at least one key with 2 values from two shamir providers")
+}
+
+// ---------------------------------------------------------------------------
+// BuildOrPanic()
+// ---------------------------------------------------------------------------
+
+func TestBuildOrPanic_Success(t *testing.T) {
+	b := &confignet.ConfigurationBuilder{}
+	b.Add(&providers.JSONConfigurationProvider{FilePath: "app.json"})
+
+	assert.NotPanics(t, func() {
+		conf := b.BuildOrPanic()
+		assert.NotNil(t, conf)
+	})
+}
+
+func TestBuildOrPanic_PanicsOnMissingFile(t *testing.T) {
+	b := &confignet.ConfigurationBuilder{}
+	b.Add(&providers.JSONConfigurationProvider{FilePath: "nonexistent-file-xyz.json"})
+
+	assert.Panics(t, func() {
+		b.BuildOrPanic()
+	})
+}
+
+// ---------------------------------------------------------------------------
+// SetLogger()
+// ---------------------------------------------------------------------------
+
+type captureLogger struct {
+	messages []string
+}
+
+func (l *captureLogger) Printf(format string, args ...interface{}) {
+	l.messages = append(l.messages, fmt.Sprintf(format, args...))
+}
+
+func TestSetLogger_CustomLogger(t *testing.T) {
+	cl := &captureLogger{}
+	confignet.SetLogger(cl)
+
+	b := &confignet.ConfigurationBuilder{}
+	b.Add(&providers.JSONConfigurationProvider{FilePath: "app.json"})
+	_ = b.Build()
+
+	// Builder logs at least one message when adding a provider
+	assert.Greater(t, len(cl.messages), 0, "expected logger to receive messages")
+
+	// Restore default logger (stdLogger is unexported, so we use a safe fallback)
+	confignet.SetLogger(&captureLogger{}) // keep a non-nil logger
+}
+
+func TestSetLogger_NilIsIgnored(t *testing.T) {
+	assert.NotPanics(t, func() {
+		confignet.SetLogger(nil)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// AES encryption round-trip
+// ---------------------------------------------------------------------------
+
+func TestAES_EncryptDecryptRoundTrip(t *testing.T) {
+	secret := "mysupersecretkey"
+	plaintext := []byte("hello, world!")
+
+	encrypted, err := internal.EncryptBytesToBase64(plaintext, secret)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, encrypted)
+
+	decrypted, err := internal.DecryptBase64ToBytes(encrypted, secret)
+	assert.NoError(t, err)
+	assert.Equal(t, plaintext, decrypted)
+}
+
+func TestAES_EncryptDecryptRoundTrip_LongText(t *testing.T) {
+	secret := "anothersecret"
+	plaintext := []byte("a longer text that exceeds the AES block size boundary definitely yes it does")
+
+	encrypted, err := internal.EncryptBytesToBase64(plaintext, secret)
+	assert.NoError(t, err)
+
+	decrypted, err := internal.DecryptBase64ToBytes(encrypted, secret)
+	assert.NoError(t, err)
+	assert.Equal(t, plaintext, decrypted)
+}
+
+func TestAES_DecryptBadBase64(t *testing.T) {
+	_, err := internal.DecryptBase64ToBytes("!!!notbase64!!!", "secret")
+	assert.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// internal.MarshalToFile() / UnmarshalFromFile()
+// ---------------------------------------------------------------------------
+
+type marshalPayload struct {
+	Name  string `json:"name"`
+	Value int    `json:"value"`
+}
+
+func TestMarshalToFile_RoundTrip(t *testing.T) {
+	src := marshalPayload{Name: "test", Value: 42}
+	path := filepath.Join(t.TempDir(), "output.json")
+
+	err := internal.MarshalToFile(path, src, func(v interface{}) ([]byte, error) {
+		return json.Marshal(v)
+	})
+	assert.NoError(t, err)
+
+	var got marshalPayload
+	err = internal.UnmarshalFromFile(path, &got, func(in []byte, out interface{}) error {
+		return json.Unmarshal(in, out)
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, src.Name, got.Name)
+	assert.Equal(t, src.Value, got.Value)
+}
+
+func TestUnmarshalFromFile_NotFound(t *testing.T) {
+	var dummy map[string]interface{}
+	err := internal.UnmarshalFromFile("no-such-file.json", &dummy, json.Unmarshal)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// ---------------------------------------------------------------------------
+// AesConfigurationDecrypter.Init() — path with ConfigFilePath set
+// ---------------------------------------------------------------------------
+
+func TestAesDecrypter_InitWithConfigFile(t *testing.T) {
+	// AesConfigurationDecrypter.Init reads a settings file (meta-config) via
+	// ConfigureConfigurationProviders, then calls GetValue(SecretConfigPath).
+	// We need:
+	//   1. A data file holding the actual secret value.
+	//   2. A settings file pointing to that data file as a provider.
+
+	tmpDir := t.TempDir()
+
+	// Step 1: data file with the secret
+	dataFile := filepath.Join(tmpDir, "data.json")
+	err := os.WriteFile(dataFile, []byte(`{"mysecretpath": "mysecret"}`), 0600)
+	assert.NoError(t, err)
+
+	// Step 2: settings file referencing the data file
+	settingsContent := fmt.Sprintf(`{"providers":[{"name":"json","properties":{"filePath":%q}}]}`, dataFile)
+	settingsFile := filepath.Join(tmpDir, "settings.json")
+	err = os.WriteFile(settingsFile, []byte(settingsContent), 0600)
+	assert.NoError(t, err)
+
+	dec := &decrypters.AesConfigurationDecrypter{
+		ConfigFileType:   "json",
+		ConfigFilePath:   settingsFile,
+		SecretConfigPath: "mysecretpath",
+	}
+
+	dec.Init(&confignet.ConfigurationBuilder{})
+	assert.Equal(t, "mysecret", dec.Secret)
+}
+
+// ---------------------------------------------------------------------------
+// Binder error paths
+// ---------------------------------------------------------------------------
+
+func TestBinder_InvalidIntValue(t *testing.T) {
+	t.Setenv("config__Obj1__PropertyInt", "notanint")
+
+	var b extensions.IConfigurationBuilder = &confignet.ConfigurationBuilder{}
+	b.Add(&providers.EnvConfigurationProvider{})
+	conf := b.Build()
+
+	cfg := myConfig{Obj1: &subObj{}}
+	err := conf.Bind("config", &cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, cfg.Obj1.PropertyInt) // parse failed, keeps zero
+}
+
+func TestBinder_InvalidBoolValue(t *testing.T) {
+	t.Setenv("config__Obj1__PropertyBool", "notabool")
+
+	var b extensions.IConfigurationBuilder = &confignet.ConfigurationBuilder{}
+	b.Add(&providers.EnvConfigurationProvider{})
+	conf := b.Build()
+
+	cfg := myConfig{Obj1: &subObj{}}
+	err := conf.Bind("config", &cfg)
+	assert.NoError(t, err)
+	assert.False(t, cfg.Obj1.PropertyBool)
+}
+
+func TestBinder_InvalidFloatValue(t *testing.T) {
+	t.Setenv("config__Obj1__PropertyFloat32", "notafloat")
+
+	var b extensions.IConfigurationBuilder = &confignet.ConfigurationBuilder{}
+	b.Add(&providers.EnvConfigurationProvider{})
+	conf := b.Build()
+
+	cfg := myConfig{Obj1: &subObj{}}
+	err := conf.Bind("config", &cfg)
+	assert.NoError(t, err)
+	var expected float32 = 0
+	assert.Equal(t, expected, cfg.Obj1.PropertyFloat32)
+}
+
+func TestBinder_InvalidTimeValue(t *testing.T) {
+	t.Setenv("config__Obj1__Time", "not-a-time")
+
+	var b extensions.IConfigurationBuilder = &confignet.ConfigurationBuilder{}
+	b.Add(&providers.EnvConfigurationProvider{})
+	conf := b.Build()
+
+	cfg := myConfig{Obj1: &subObj{}}
+	err := conf.Bind("config", &cfg)
+	assert.NoError(t, err)
+	assert.True(t, cfg.Obj1.Time.IsZero())
+}
+
+func TestBinder_ArrayOutOfRange(t *testing.T) {
+	// ArrayInt is *[3]int — index 99 is out of range, should not panic
+	t.Setenv("config__Obj1__ArrayInt__99", "42")
+
+	var b extensions.IConfigurationBuilder = &confignet.ConfigurationBuilder{}
+	b.Add(&providers.JSONConfigurationProvider{FilePath: "app.json"})
+	b.Add(&providers.EnvConfigurationProvider{})
+	conf := b.Build()
+
+	cfg := myConfig{}
+	err := conf.Bind("config", &cfg)
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg.Obj1)
+	assert.NotNil(t, cfg.Obj1.ArrayInt)
+}

--- a/tests/coverage_gaps_test.go
+++ b/tests/coverage_gaps_test.go
@@ -211,15 +211,11 @@ func TestMarshalToFile_RoundTrip(t *testing.T) {
 	src := marshalPayload{Name: "test", Value: 42}
 	path := filepath.Join(t.TempDir(), "output.json")
 
-	err := internal.MarshalToFile(path, src, func(v interface{}) ([]byte, error) {
-		return json.Marshal(v)
-	})
+	err := internal.MarshalToFile(path, src, json.Marshal)
 	assert.NoError(t, err)
 
 	var got marshalPayload
-	err = internal.UnmarshalFromFile(path, &got, func(in []byte, out interface{}) error {
-		return json.Unmarshal(in, out)
-	})
+	err = internal.UnmarshalFromFile(path, &got, json.Unmarshal)
 	assert.NoError(t, err)
 	assert.Equal(t, src.Name, got.Name)
 	assert.Equal(t, src.Value, got.Value)
@@ -306,7 +302,7 @@ func TestBinder_InvalidFloatValue(t *testing.T) {
 	cfg := myConfig{Obj1: &subObj{}}
 	err := conf.Bind("config", &cfg)
 	assert.NoError(t, err)
-	var expected float32 = 0
+	var expected float32
 	assert.Equal(t, expected, cfg.Obj1.PropertyFloat32)
 }
 

--- a/tests/default_tag_test.go
+++ b/tests/default_tag_test.go
@@ -1,0 +1,125 @@
+package tests
+
+import (
+	"testing"
+
+	confignet "github.com/maurik77/go-confignet"
+	"github.com/maurik77/go-confignet/extensions"
+	"github.com/maurik77/go-confignet/providers"
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------------------------------------------------------------------------
+// Test structs
+// ---------------------------------------------------------------------------
+
+type defaultConfig struct {
+	Port    int     `default:"8080"`
+	Host    string  `default:"localhost"`
+	Debug   bool    `default:"true"`
+	Rate    float64 `default:"1.5"`
+	Nested  defaultNested
+	PtrSub  *defaultNested
+}
+
+type defaultNested struct {
+	Timeout int    `default:"30"`
+	Name    string `default:"worker"`
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func buildEmptyConf() extensions.IConfiguration {
+	// EnvConfigurationProvider with a prefix that will never match anything,
+	// so the provider supplies no keys — defaults must fill the gaps.
+	var b extensions.IConfigurationBuilder = &confignet.ConfigurationBuilder{}
+	b.Add(&providers.EnvConfigurationProvider{Prefix: "zzznomatch__"})
+	return b.Build()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+func TestDefaultTag_AppliedWhenMissing(t *testing.T) {
+	conf := buildEmptyConf()
+	var cfg defaultConfig
+	err := conf.Bind("defaults", &cfg)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 8080, cfg.Port)
+	assert.Equal(t, "localhost", cfg.Host)
+	assert.Equal(t, true, cfg.Debug)
+	assert.InDelta(t, 1.5, cfg.Rate, 1e-9)
+}
+
+func TestDefaultTag_NestedStruct(t *testing.T) {
+	conf := buildEmptyConf()
+	var cfg defaultConfig
+	err := conf.Bind("defaults", &cfg)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 30, cfg.Nested.Timeout)
+	assert.Equal(t, "worker", cfg.Nested.Name)
+}
+
+func TestDefaultTag_OverriddenByProvider(t *testing.T) {
+	// The JSON file has defaults__Port = 9090 and defaults__Host = "example.com"
+	t.Setenv("defaults__Port", "9090")
+	t.Setenv("defaults__Host", "example.com")
+
+	var b extensions.IConfigurationBuilder = &confignet.ConfigurationBuilder{}
+	b.Add(&providers.EnvConfigurationProvider{})
+	conf := b.Build()
+
+	var cfg defaultConfig
+	err := conf.Bind("defaults", &cfg)
+	assert.NoError(t, err)
+
+	// Provider values win over tag defaults
+	assert.Equal(t, 9090, cfg.Port)
+	assert.Equal(t, "example.com", cfg.Host)
+	// Fields not set by provider still get their defaults
+	assert.Equal(t, true, cfg.Debug)
+	assert.InDelta(t, 1.5, cfg.Rate, 1e-9)
+}
+
+func TestDefaultTag_ProviderExplicitZeroOverridesDefault(t *testing.T) {
+	// Provider explicitly sets Port to 0 — this should win over the default.
+	t.Setenv("defaults__Port", "0")
+
+	var b extensions.IConfigurationBuilder = &confignet.ConfigurationBuilder{}
+	b.Add(&providers.EnvConfigurationProvider{})
+	conf := b.Build()
+
+	var cfg defaultConfig
+	err := conf.Bind("defaults", &cfg)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 0, cfg.Port)
+}
+
+func TestDefaultTag_NoDefaultTag_KeepsZero(t *testing.T) {
+	// A struct without default tags should still have zero values when no provider matches.
+	conf := buildEmptyConf()
+	var cfg struct {
+		Port int
+		Host string
+	}
+	err := conf.Bind("notag", &cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, cfg.Port)
+	assert.Equal(t, "", cfg.Host)
+}
+
+func TestDefaultTag_PtrSubStruct_NilStaysNil(t *testing.T) {
+	// PtrSub is a *defaultNested — when no provider sets any of its fields,
+	// it should remain nil (we don't allocate just to apply defaults).
+	conf := buildEmptyConf()
+	var cfg defaultConfig
+	err := conf.Bind("defaults", &cfg)
+	assert.NoError(t, err)
+	assert.Nil(t, cfg.PtrSub)
+}

--- a/tests/settings-toml.json
+++ b/tests/settings-toml.json
@@ -1,0 +1,10 @@
+{
+  "providers": [
+    {
+      "name": "toml",
+      "properties": {
+        "filePath": "app.toml"
+      }
+    }
+  ]
+}

--- a/tests/toml_test.go
+++ b/tests/toml_test.go
@@ -1,0 +1,67 @@
+package tests
+
+import (
+	"testing"
+
+	confignet "github.com/maurik77/go-confignet"
+	"github.com/maurik77/go-confignet/extensions"
+	"github.com/maurik77/go-confignet/providers"
+	"github.com/stretchr/testify/assert"
+)
+
+func buildTomlConf(filePath string) extensions.IConfiguration {
+	var confBuilder extensions.IConfigurationBuilder = &confignet.ConfigurationBuilder{}
+	confBuilder.Add(&providers.TomlConfigurationProvider{FilePath: filePath})
+	return confBuilder.Build()
+}
+
+func TestTomlProvider_Bind(t *testing.T) {
+	conf := buildTomlConf("app.toml")
+
+	myCfg := myConfig{}
+	err := conf.Bind("config", &myCfg)
+	assert.Nil(t, err)
+
+	validateObject(t, getJSONExpectedValue(), myCfg)
+}
+
+func TestTomlProvider_BindSubSection(t *testing.T) {
+	conf := buildTomlConf("app.toml")
+
+	subObjConf := subObj{}
+	err := conf.Bind("config/Obj1", &subObjConf)
+	assert.Nil(t, err)
+
+	validateSubObject(t, *getJSONExpectedValue().Obj1, subObjConf)
+}
+
+func TestTomlProvider_GetValue(t *testing.T) {
+	conf := buildTomlConf("app.toml")
+
+	assert.Equal(t, "TestObj1", conf.GetValue("config/Obj1/PropertyString"))
+	assert.Equal(t, "45", conf.GetValue("config/PropertyInt8"))
+	assert.Equal(t, "true", conf.GetValue("config/Obj1/PropertyBool"))
+	assert.Equal(t, "1.5", conf.GetValue("config/Obj1/PropertyFloat32"))
+}
+
+func TestTomlProvider_MissingFile(t *testing.T) {
+	conf := buildTomlConf("nonexistent.toml")
+
+	cfg := myConfig{}
+	err := conf.Bind("config", &cfg)
+	// Bind itself does not error on missing file; the provider logs and returns empty data
+	assert.Nil(t, err)
+	assert.Nil(t, cfg.Obj1)
+}
+
+func TestTomlProvider_MetaConfig(t *testing.T) {
+	var confBuilder extensions.IConfigurationBuilder = &confignet.ConfigurationBuilder{}
+	confBuilder.ConfigureConfigurationProviders(confignet.ConfigFileTypeJSON, "settings-toml.json")
+	conf := confBuilder.Build()
+
+	myCfg := myConfig{}
+	err := conf.Bind("config", &myCfg)
+	assert.Nil(t, err)
+	assert.NotNil(t, myCfg.Obj1)
+	assert.Equal(t, "TestObj1", myCfg.Obj1.PropertyString)
+}


### PR DESCRIPTION
  Summary

  Adds default struct tag support to the binder. Fields tagged with `default:"value"` receive that value when no provider supplies a key for that
  field. Provider values — including an explicit zero — always win.

  - internal/defaults.go: new ApplyDefaults() walks the struct tree via reflection and applies default tags to zero-value fields before provider
  binding
  - configuration.go: Bind() calls ApplyDefaults(target) before iterating providers
  - tests/default_tag_test.go: 6 tests covering scalars, nested structs, provider override, explicit-zero override, no-tag fallback, and nil pointer
  sub-structs

  Design rationale

  Preferred over a SetDefault(key, value) API because the default lives next to the field it belongs to — no separate setup call, no string key
  duplication, no typo risk. Works with nested structs automatically. Pointer-to-struct fields remain nil when no provider sets them (no phantom
  allocation).

  type ServerConfig struct {
      Host    string  `default:"localhost"`
      Port    int     `default:"8080"`
      Timeout int     `default:"30"`
  }

  Limitation: static strings only. Dynamic/computed defaults still require a lowest-priority in-memory provider.

  Test plan

  - cd tests && go test ./... passes
  - task build exits cleanly (no linter errors)
  - Provider value overrides default (including explicit "0")
  - Nested struct fields receive their own defaults
  - *SubStruct pointer fields stay nil when no provider sets them