### PR TITLE
feat: add BindStrict() to detect unknown configuration keys

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -3,6 +3,7 @@ package confignet
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 	"sync"
 
@@ -91,6 +92,51 @@ func (conf *Configuration) Bind(section string, target interface{}) error {
 	for _, p := range conf.configurationProvidersInfo {
 		props := filterProperties(section, p)
 		conf.bindProps(p, props, target)
+	}
+
+	return nil
+}
+
+// BindStrict is like Bind but returns an error if any configuration key
+// in the matched section does not correspond to a field in the target struct.
+func BindStrict(section string, target interface{}) error {
+	initializeDefaultConfig()
+	return conf.BindStrict(section, target)
+}
+
+// BindStrict is like Bind but returns an error if any configuration key
+// in the matched section does not correspond to a field in the target struct.
+func (conf *Configuration) BindStrict(section string, target interface{}) error {
+	if err := conf.Bind(section, target); err != nil {
+		return err
+	}
+
+	t := reflect.TypeOf(target)
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	seen := map[string]struct{}{}
+	var unknown []string
+
+	for _, p := range conf.configurationProvidersInfo {
+		props := filterProperties(section, p)
+		separator := p.Provider.GetSeparator()
+		for key := range props {
+			if _, done := seen[key]; done {
+				continue
+			}
+			seen[key] = struct{}{}
+			parts := strings.Split(key, separator)
+			if !internal.IsValidPath(t, parts) {
+				unknown = append(unknown, strings.Join(parts, "."))
+			}
+		}
+	}
+
+	if len(unknown) > 0 {
+		sort.Strings(unknown)
+		return fmt.Errorf("confignet: unknown configuration keys: %s", strings.Join(unknown, ", "))
 	}
 
 	return nil

--- a/extensions/configuration.go
+++ b/extensions/configuration.go
@@ -4,6 +4,7 @@ package extensions
 type IConfiguration interface {
 	GetProviders() []ConfigurationProviderInfo
 	Bind(section string, value interface{}) error
+	BindStrict(section string, value interface{}) error
 	GetValue(section string) string
 }
 

--- a/internal/strict.go
+++ b/internal/strict.go
@@ -1,0 +1,42 @@
+package internal
+
+import (
+	"reflect"
+	"strconv"
+)
+
+// IsValidPath reports whether the sequence of parts navigates to a known
+// field (or element) inside the type t. It is used by BindStrict to detect
+// configuration keys that have no matching struct field.
+func IsValidPath(t reflect.Type, parts []string) bool {
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	if len(parts) == 0 {
+		return true
+	}
+
+	part := parts[0]
+	rest := parts[1:]
+
+	switch t.Kind() {
+	case reflect.Struct:
+		field, ok := t.FieldByName(part)
+		if !ok {
+			return false
+		}
+		return IsValidPath(field.Type, rest)
+	case reflect.Slice, reflect.Array:
+		if _, err := strconv.Atoi(part); err != nil {
+			return false
+		}
+		return IsValidPath(t.Elem(), rest)
+	case reflect.Map:
+		// part is the map key — always valid; validate rest against value type
+		return IsValidPath(t.Elem(), rest)
+	default:
+		// scalar — no further parts expected
+		return len(rest) == 0
+	}
+}

--- a/tests/bind_strict_test.go
+++ b/tests/bind_strict_test.go
@@ -1,0 +1,130 @@
+package tests
+
+import (
+	"testing"
+
+	confignet "github.com/maurik77/go-confignet"
+	"github.com/maurik77/go-confignet/extensions"
+	"github.com/maurik77/go-confignet/providers"
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------------------------------------------------------------------------
+// Test structs
+// ---------------------------------------------------------------------------
+
+type strictConfig struct {
+	Host    string
+	Port    int
+	Nested  strictNested
+	Tags    map[string]string
+	Items   []string
+}
+
+type strictNested struct {
+	Timeout int
+	Name    string
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func buildEnvConf() extensions.IConfiguration {
+	var b extensions.IConfigurationBuilder = &confignet.ConfigurationBuilder{}
+	b.Add(&providers.EnvConfigurationProvider{})
+	return b.Build()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+func TestBindStrict_NoUnknownKeys(t *testing.T) {
+	t.Setenv("app__Host", "localhost")
+	t.Setenv("app__Port", "8080")
+
+	conf := buildEnvConf()
+	var cfg strictConfig
+	err := conf.BindStrict("app", &cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, "localhost", cfg.Host)
+	assert.Equal(t, 8080, cfg.Port)
+}
+
+func TestBindStrict_UnknownKey(t *testing.T) {
+	t.Setenv("app__Hsot", "localhost") // typo: Hsot instead of Host
+
+	conf := buildEnvConf()
+	var cfg strictConfig
+	err := conf.BindStrict("app", &cfg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Hsot")
+}
+
+func TestBindStrict_MultipleUnknownKeys(t *testing.T) {
+	t.Setenv("app__Hsot", "localhost") // typo
+	t.Setenv("app__Prot", "8080")     // typo
+
+	conf := buildEnvConf()
+	var cfg strictConfig
+	err := conf.BindStrict("app", &cfg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Hsot")
+	assert.Contains(t, err.Error(), "Prot")
+}
+
+func TestBindStrict_NestedValidKey(t *testing.T) {
+	t.Setenv("app__Nested__Timeout", "30")
+
+	conf := buildEnvConf()
+	var cfg strictConfig
+	err := conf.BindStrict("app", &cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, 30, cfg.Nested.Timeout)
+}
+
+func TestBindStrict_NestedUnknownKey(t *testing.T) {
+	t.Setenv("app__Nested__Tiemout", "30") // typo
+
+	conf := buildEnvConf()
+	var cfg strictConfig
+	err := conf.BindStrict("app", &cfg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Tiemout")
+}
+
+func TestBindStrict_SliceIndexValid(t *testing.T) {
+	t.Setenv("app__Items__0", "hello")
+
+	conf := buildEnvConf()
+	var cfg strictConfig
+	err := conf.BindStrict("app", &cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, "hello", cfg.Items[0])
+}
+
+func TestBindStrict_MapKeyValid(t *testing.T) {
+	t.Setenv("app__Tags__env", "prod")
+
+	conf := buildEnvConf()
+	var cfg strictConfig
+	err := conf.BindStrict("app", &cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, "prod", cfg.Tags["env"])
+}
+
+func TestBindStrict_NilTarget(t *testing.T) {
+	conf := buildEnvConf()
+	err := conf.BindStrict("app", nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "nil")
+}
+
+func TestBindStrict_NonPointerTarget(t *testing.T) {
+	conf := buildEnvConf()
+	var cfg strictConfig
+	err := conf.BindStrict("app", cfg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "non-pointer")
+}


### PR DESCRIPTION
BindStrict() runs the normal Bind() then performs a reverse pass: for every key matched by the section prefix it navigates the target struct type via reflection (IsValidPath) and reports any key that resolves to no known field, slice index, or map entry.

- internal/strict.go: IsValidPath() navigates reflect.Type trees handling structs, slices/arrays, maps, and pointers
- extensions/configuration.go: BindStrict added to IConfiguration
- configuration.go: Configuration.BindStrict() + package-level BindStrict()
- tests/bind_strict_test.go: 9 tests covering valid keys, typos, nested structs, slices, maps, nil/non-pointer targets