### PR TITLE
Release: v0.1.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Requires **Go 1.18** or later.
   - [Split Secrets (Shamir)](#split-secrets-shamir)
   - [AES Encryption](#aes-encryption)
 - [Meta-Configuration](#meta-configuration)
+- [Struct Tags](#struct-tags)
+  - [confignet tag — key mapping](#confignet-tag--key-mapping)
+  - [default tag — default values](#default-tag--default-values)
+- [Strict Binding](#strict-binding)
 - [Supported Field Types](#supported-field-types)
 - [Provider Override Order](#provider-override-order)
 - [Custom Providers](#custom-providers)
@@ -125,7 +129,7 @@ Each provider uses its own natural key separator. `Bind` translates between them
 
 | Provider           | Separator | Example key                      |
 |--------------------|-----------|----------------------------------|
-| JSON / YAML        | `.`       | `app.Database.Host`              |
+| JSON / YAML / TOML | `.`       | `app.Database.Host`              |
 | Environment        | `__`      | `app__Database__Host`            |
 | Command line       | `-`       | `app-Database-Host`              |
 | Azure Key Vault    | `--`      | `app--Database--Host`            |
@@ -281,6 +285,7 @@ confBuilder.Add(&providers.TomlConfigurationProvider{FilePath: "config/app.toml"
 ```
 
 **Note:** TOML arrays of tables (`[[...]]`) and inline arrays are both fully supported.
+
 
 ---
 
@@ -572,6 +577,111 @@ confBuilder.ConfigureConfigurationProvidersFromEnv()
 |----------|-------------------------------|
 | `aes`    | AesConfigurationDecrypter     |
 | `shamir` | ShamirConfigurationDecrypter  |
+
+---
+
+## Struct Tags
+
+### `confignet` tag — key mapping
+
+By default, the binder matches config keys to struct fields by field name. The `confignet` tag lets you declare a different key name, enabling natural naming conventions in config files (e.g. `snake_case`) while keeping idiomatic `PascalCase` in Go:
+
+```go
+type DatabaseConfig struct {
+    Host    string `confignet:"host"`
+    Port    int    `confignet:"port"`
+    Timeout int    `confignet:"connection_timeout"`
+    Name    string // no tag — matched by field name "Name"
+}
+```
+
+This works with every provider. A JSON file can use `host`, an env var can use `database__connection_timeout`, a Key Vault secret can use `database--connection-timeout` — all bind to the same struct fields.
+
+```json
+{
+  "database": {
+    "host": "localhost",
+    "port": 5432,
+    "connection_timeout": 30
+  }
+}
+```
+
+```bash
+export database__connection_timeout=60
+```
+
+A per-type field index is cached after the first `Bind()` call, so there is no runtime cost on subsequent calls.
+
+---
+
+### `default` tag — default values
+
+Fields tagged with `default` receive that value when no provider supplies a value for that key. Provider values (including explicit zero) always override the default:
+
+```go
+type ServerConfig struct {
+    Host    string  `default:"localhost"`
+    Port    int     `default:"8080"`
+    Debug   bool    `default:"false"`
+    Timeout int     `default:"30"`
+}
+```
+
+```go
+var cfg ServerConfig
+conf.Bind("server", &cfg)
+// cfg.Host == "localhost"  (if no provider set it)
+// cfg.Port == 8080         (if no provider set it)
+```
+
+Defaults are applied before provider binding, so:
+
+```
+default tag  →  provider value (wins if present)  →  final value
+```
+
+Tags are supported on nested struct fields as well:
+
+```go
+type Config struct {
+    Server  ServerConfig
+    DB      DatabaseConfig
+}
+
+type DatabaseConfig struct {
+    Port    int    `confignet:"port" default:"5432"`
+    MaxConn int    `confignet:"max_connections" default:"10"`
+}
+```
+
+**Limitation**: default values are static strings. For dynamic defaults (e.g. computed at startup), add a lowest-priority in-memory provider before other providers.
+
+---
+
+## Strict Binding
+
+`BindStrict()` is a drop-in replacement for `Bind()` that returns an error if the configuration contains any key that does not correspond to a field in the target struct. This catches typos in config files and environment variables at startup:
+
+```go
+var cfg DatabaseConfig
+err := conf.BindStrict("database", &cfg)
+// err: "confignet: unknown configuration keys: connection_timout, hsot"
+```
+
+```go
+// These are equivalent when no unknown keys exist:
+conf.Bind("database", &cfg)
+conf.BindStrict("database", &cfg)
+```
+
+`BindStrict` is tag-aware — keys matching a `confignet` tag are correctly accepted. It also handles slices, arrays, and maps: numeric indices for slices and arbitrary keys for maps are never flagged as unknown.
+
+A package-level `BindStrict` function is also available (same as `Bind`):
+
+```go
+err := confignet.BindStrict("app", &cfg)
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Requires **Go 1.18** or later.
 - [Built-in Providers](#built-in-providers)
   - [JSON](#json)
   - [YAML](#yaml)
+  - [TOML](#toml)
   - [Environment Variables](#environment-variables)
   - [Command Line Arguments](#command-line-arguments)
   - [Azure Key Vault](#azure-key-vault)
@@ -69,6 +70,9 @@ The meta-configuration system lets you list providers, their properties, and the
 
 **Come from an ASP.NET Core background.**
 The builder pattern, provider interface, and layered override model are directly inspired by `Microsoft.Extensions.Configuration`. The mental model transfers.
+
+**Want predictable, explicit key matching.**
+go-confignet is case-sensitive by design. `Database.Host` and `database.host` are distinct keys, exactly as they are in Go struct field names. Some libraries silently fold all keys to lowercase — a convenience that creates subtle bugs when two keys differ only by case, and unexpected behaviour when working with secrets or provider-specific naming conventions. go-confignet never normalises your keys behind your back.
 
 ---
 
@@ -238,6 +242,45 @@ app:
 ```go
 confBuilder.Add(&providers.YamlConfigurationProvider{FilePath: "config/app.yaml"})
 ```
+
+---
+
+### TOML
+
+Loads configuration from a TOML file. Separator: `.`
+
+```go
+type TomlConfigurationProvider struct {
+    FilePath string // default: "app.toml"
+}
+```
+
+**Example file:**
+
+```toml
+[app]
+PropertyInt8 = 45
+
+[app.Database]
+Host = "localhost"
+Port = 5432
+
+[[app.Items]]
+Name  = "first"
+Value = 10
+
+[[app.Items]]
+Name  = "second"
+Value = 20
+```
+
+**Usage:**
+
+```go
+confBuilder.Add(&providers.TomlConfigurationProvider{FilePath: "config/app.toml"})
+```
+
+**Note:** TOML arrays of tables (`[[...]]`) and inline arrays are both fully supported.
 
 ---
 
@@ -517,6 +560,7 @@ confBuilder.ConfigureConfigurationProvidersFromEnv()
 |------------|----------------------------------|
 | `json`     | JSONConfigurationProvider        |
 | `yaml`     | YamlConfigurationProvider        |
+| `toml`     | TomlConfigurationProvider        |
 | `env`      | EnvConfigurationProvider         |
 | `cmdline`  | CmdLineConfigurationProvider     |
 | `keyvault` | KeyVaultConfigurationProvider    |

--- a/common.go
+++ b/common.go
@@ -58,6 +58,7 @@ func init() {
 	RegisterConfigurationSource(&providers.EnvConfigurationProviderSource{})
 	RegisterConfigurationSource(&providers.JSONConfigurationProviderSource{})
 	RegisterConfigurationSource(&providers.YamlConfigurationProviderSource{})
+	RegisterConfigurationSource(&providers.TomlConfigurationProviderSource{})
 	RegisterConfigurationSource(&providers.KeyVaultConfigurationProviderSource{})
 	RegisterConfigurationSource(&ChainedConfigurationProviderSource{})
 	RegisterDecrypterSource(&decrypters.AesConfigurationDecrypterSource{})

--- a/configuration.go
+++ b/configuration.go
@@ -3,6 +3,7 @@ package confignet
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 	"sync"
 
@@ -93,6 +94,51 @@ func (conf *Configuration) Bind(section string, target interface{}) error {
 	for _, p := range conf.configurationProvidersInfo {
 		props := filterProperties(section, p)
 		conf.bindProps(p, props, target)
+	}
+
+	return nil
+}
+
+// BindStrict is like Bind but returns an error if any configuration key
+// in the matched section does not correspond to a field in the target struct.
+func BindStrict(section string, target interface{}) error {
+	initializeDefaultConfig()
+	return conf.BindStrict(section, target)
+}
+
+// BindStrict is like Bind but returns an error if any configuration key
+// in the matched section does not correspond to a field in the target struct.
+func (conf *Configuration) BindStrict(section string, target interface{}) error {
+	if err := conf.Bind(section, target); err != nil {
+		return err
+	}
+
+	t := reflect.TypeOf(target)
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	seen := map[string]struct{}{}
+	var unknown []string
+
+	for _, p := range conf.configurationProvidersInfo {
+		props := filterProperties(section, p)
+		separator := p.Provider.GetSeparator()
+		for key := range props {
+			if _, done := seen[key]; done {
+				continue
+			}
+			seen[key] = struct{}{}
+			parts := strings.Split(key, separator)
+			if !internal.IsValidPath(t, parts) {
+				unknown = append(unknown, strings.Join(parts, "."))
+			}
+		}
+	}
+
+	if len(unknown) > 0 {
+		sort.Strings(unknown)
+		return fmt.Errorf("confignet: unknown configuration keys: %s", strings.Join(unknown, ", "))
 	}
 
 	return nil

--- a/configuration.go
+++ b/configuration.go
@@ -88,6 +88,8 @@ func (conf *Configuration) Bind(section string, target interface{}) error {
 		return &InvalidBindError{reflect.TypeOf(target)}
 	}
 
+	internal.ApplyDefaults(target)
+
 	for _, p := range conf.configurationProvidersInfo {
 		props := filterProperties(section, p)
 		conf.bindProps(p, props, target)

--- a/extensions/configuration.go
+++ b/extensions/configuration.go
@@ -4,6 +4,7 @@ package extensions
 type IConfiguration interface {
 	GetProviders() []ConfigurationProviderInfo
 	Bind(section string, value interface{}) error
+	BindStrict(section string, value interface{}) error
 	GetValue(section string) string
 }
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 // indirect
+	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJ
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 h1:XRzhVemXdgvJqCH0sFfrBUTnUJSBrBf7++ypk+twtRs=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=

--- a/internal/binder.go
+++ b/internal/binder.go
@@ -20,10 +20,10 @@ func fillObject(parent reflect.Value, value string, parts ...string) {
 	}
 
 	fieldName := parts[0]
-	nestedField := parent.FieldByName(fieldName)
+	nestedField, ok := fieldByKey(parent, fieldName)
 
-	if !nestedField.IsValid() {
-		Logger.Printf("Configuration:Unable to find field %v in the object %v", fieldName, nestedField)
+	if !ok {
+		Logger.Printf("Configuration:Unable to find field %v in the object %v", fieldName, parent.Type())
 		return
 	}
 

--- a/internal/defaults.go
+++ b/internal/defaults.go
@@ -1,0 +1,45 @@
+package internal
+
+import "reflect"
+
+// ApplyDefaults walks the struct pointed to by target and sets any field
+// tagged with `default:"<value>"` to that value when the field currently
+// holds its zero value. Provider-supplied values are applied afterwards by
+// the caller, so they always take precedence over tag defaults.
+func ApplyDefaults(target interface{}) {
+	rv := reflect.ValueOf(target)
+	if rv.Kind() != reflect.Ptr || rv.IsNil() {
+		return
+	}
+	applyDefaultsToStruct(rv.Elem())
+}
+
+func applyDefaultsToStruct(v reflect.Value) {
+	if v.Kind() != reflect.Struct {
+		return
+	}
+	t := v.Type()
+	for i := 0; i < t.NumField(); i++ {
+		field := v.Field(i)
+		fieldType := t.Field(i)
+
+		// Apply the default only for scalar/pointer fields (not structs themselves).
+		if defaultVal, ok := fieldType.Tag.Lookup("default"); ok &&
+			field.Kind() != reflect.Struct &&
+			field.IsZero() {
+			fillField(field, defaultVal, -1)
+		}
+
+		// Recurse into nested structs and already-allocated pointer-to-structs.
+		switch field.Kind() {
+		case reflect.Struct:
+			applyDefaultsToStruct(field)
+		case reflect.Ptr:
+			if !field.IsNil() {
+				if elem := field.Elem(); elem.Kind() == reflect.Struct {
+					applyDefaultsToStruct(elem)
+				}
+			}
+		}
+	}
+}

--- a/internal/fieldcache.go
+++ b/internal/fieldcache.go
@@ -1,0 +1,57 @@
+package internal
+
+import (
+	"reflect"
+	"sync"
+)
+
+const TagName = "confignet"
+
+// fieldCache maps reflect.Type → (key string → field index).
+// Built once per struct type and reused on every subsequent lookup.
+var fieldCache sync.Map // map[reflect.Type]map[string]int
+
+// fieldByKey returns the struct field of v whose confignet tag (or, if absent,
+// whose field name) matches key. The second return value is false when no
+// matching field exists.
+func fieldByKey(v reflect.Value, key string) (reflect.Value, bool) {
+	index, ok := cachedFieldIndex(v.Type(), key)
+	if !ok {
+		return reflect.Value{}, false
+	}
+	return v.Field(index), true
+}
+
+// typeFieldIndex returns the field index inside type t whose confignet tag
+// (or field name) matches key, using the per-type cache.
+func typeFieldIndex(t reflect.Type, key string) (int, bool) {
+	return cachedFieldIndex(t, key)
+}
+
+func cachedFieldIndex(t reflect.Type, key string) (int, bool) {
+	if v, ok := fieldCache.Load(t); ok {
+		m := v.(map[string]int)
+		idx, found := m[key]
+		return idx, found
+	}
+
+	m := buildIndex(t)
+	fieldCache.Store(t, m)
+	idx, found := m[key]
+	return idx, found
+}
+
+// buildIndex scans all exported fields of t and maps each field's lookup key
+// (confignet tag value, falling back to field name) to its index.
+func buildIndex(t reflect.Type) map[string]int {
+	m := make(map[string]int, t.NumField())
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		key := f.Tag.Get(TagName)
+		if key == "" {
+			key = f.Name
+		}
+		m[key] = i
+	}
+	return m
+}

--- a/internal/strict.go
+++ b/internal/strict.go
@@ -6,8 +6,9 @@ import (
 )
 
 // IsValidPath reports whether the sequence of parts navigates to a known
-// field (or element) inside the type t. It is used by BindStrict to detect
-// configuration keys that have no matching struct field.
+// field (or element) inside the type t, respecting confignet struct tags.
+// It is used by BindStrict to detect configuration keys that have no
+// matching struct field.
 func IsValidPath(t reflect.Type, parts []string) bool {
 	for t.Kind() == reflect.Ptr {
 		t = t.Elem()
@@ -22,11 +23,11 @@ func IsValidPath(t reflect.Type, parts []string) bool {
 
 	switch t.Kind() {
 	case reflect.Struct:
-		field, ok := t.FieldByName(part)
+		idx, ok := typeFieldIndex(t, part)
 		if !ok {
 			return false
 		}
-		return IsValidPath(field.Type, rest)
+		return IsValidPath(t.Field(idx).Type, rest)
 	case reflect.Slice, reflect.Array:
 		if _, err := strconv.Atoi(part); err != nil {
 			return false

--- a/internal/strict.go
+++ b/internal/strict.go
@@ -1,0 +1,42 @@
+package internal
+
+import (
+	"reflect"
+	"strconv"
+)
+
+// IsValidPath reports whether the sequence of parts navigates to a known
+// field (or element) inside the type t. It is used by BindStrict to detect
+// configuration keys that have no matching struct field.
+func IsValidPath(t reflect.Type, parts []string) bool {
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	if len(parts) == 0 {
+		return true
+	}
+
+	part := parts[0]
+	rest := parts[1:]
+
+	switch t.Kind() {
+	case reflect.Struct:
+		field, ok := t.FieldByName(part)
+		if !ok {
+			return false
+		}
+		return IsValidPath(field.Type, rest)
+	case reflect.Slice, reflect.Array:
+		if _, err := strconv.Atoi(part); err != nil {
+			return false
+		}
+		return IsValidPath(t.Elem(), rest)
+	case reflect.Map:
+		// part is the map key — always valid; validate rest against value type
+		return IsValidPath(t.Elem(), rest)
+	default:
+		// scalar — no further parts expected
+		return len(rest) == 0
+	}
+}

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -20,6 +20,12 @@ func loadProperties(parent string, separator string, valueMap map[string]interfa
 			data[key] = fmt.Sprint(value)
 		case []interface{}:
 			loadArray(key, separator, v, data)
+		case []map[string]interface{}:
+			slice := make([]interface{}, len(v))
+			for i, item := range v {
+				slice[i] = item
+			}
+			loadArray(key, separator, slice, data)
 		case map[string]interface{}:
 			loadProperties(key, separator, v, data)
 		}

--- a/providers/tomlConfigurationProvider.go
+++ b/providers/tomlConfigurationProvider.go
@@ -1,0 +1,54 @@
+package providers
+
+import (
+	"github.com/BurntSushi/toml"
+	"github.com/maurik77/go-confignet/extensions"
+	"github.com/maurik77/go-confignet/internal"
+)
+
+const (
+	// DefaultTOMLFile is the default TOML configuration file name
+	DefaultTOMLFile = "app.toml"
+)
+
+// TomlConfigurationProvider loads configuration from a TOML file.
+// It uses "." (dot) as separator for hierarchical configuration.
+type TomlConfigurationProvider struct {
+	FilePath string // default: "app.toml"
+	data     map[string]string
+}
+
+// Load reads the TOML file and populates the internal key-value map.
+func (provider *TomlConfigurationProvider) Load(decrypter extensions.IConfigurationDecrypter) {
+	provider.data = make(map[string]string)
+
+	var payload map[string]interface{}
+	err := internal.UnmarshalFromFile(provider.FilePath, &payload, toml.Unmarshal)
+
+	if err != nil {
+		logger.Printf("TomlConfigurationProvider:Error during Unmarshal(): %v", err)
+	}
+
+	provider.data = internal.LoadProperties(provider.GetSeparator(), payload)
+
+	if decrypter != nil {
+		for key, value := range provider.data {
+			decrypted, err := decrypter.Decrypt(value)
+			if err != nil {
+				logger.Printf("TomlConfigurationProvider:Error calling decryption for key %v. %v", key, err)
+			} else {
+				provider.data[key] = decrypted
+			}
+		}
+	}
+}
+
+// GetData returns the loaded key-value map.
+func (provider *TomlConfigurationProvider) GetData() map[string]string {
+	return provider.data
+}
+
+// GetSeparator returns the separator used for hierarchical keys.
+func (provider *TomlConfigurationProvider) GetSeparator() string {
+	return "."
+}

--- a/providers/tomlConfigurationProviderSource.go
+++ b/providers/tomlConfigurationProviderSource.go
@@ -1,0 +1,33 @@
+package providers
+
+import (
+	"fmt"
+
+	"github.com/maurik77/go-confignet/extensions"
+)
+
+const (
+	// ConfigurationProviderTOMLIdentifier is the unique identifier for the TOML provider in settings files
+	ConfigurationProviderTOMLIdentifier = "toml"
+)
+
+// TomlConfigurationProviderSource creates TomlConfigurationProvider instances from provider settings.
+type TomlConfigurationProviderSource struct{}
+
+// NewConfigurationProvider creates a TomlConfigurationProvider from the given settings.
+func (s *TomlConfigurationProviderSource) NewConfigurationProvider(settings extensions.ProviderSettings) (extensions.IConfigurationProvider, error) {
+	if settings.Name != s.GetUniqueIdentifier() {
+		return nil, fmt.Errorf("TomlConfigurationProviderSource: settings of configuration source %s has been passed to the configuration source with unique identifier %s", settings.Name, s.GetUniqueIdentifier())
+	}
+
+	filePath := settings.GetPropertyValue("filePath", "").(string)
+
+	return &TomlConfigurationProvider{
+		FilePath: filePath,
+	}, nil
+}
+
+// GetUniqueIdentifier returns the identifier used to reference this provider in settings files.
+func (s *TomlConfigurationProviderSource) GetUniqueIdentifier() string {
+	return ConfigurationProviderTOMLIdentifier
+}

--- a/tests/app-array-syntax.json
+++ b/tests/app-array-syntax.json
@@ -1,0 +1,10 @@
+{
+  "arr": {
+    "Strings": ["hello", "world"],
+    "Items": [
+      { "Name": "first",  "Value": 10 },
+      { "Name": "second", "Value": 20 }
+    ],
+    "Fixed": [10, 42, 30]
+  }
+}

--- a/tests/app-tagged.json
+++ b/tests/app-tagged.json
@@ -1,0 +1,12 @@
+{
+  "service": {
+    "host": "db-host",
+    "port": 5432,
+    "debug": false,
+    "rate": 1.0,
+    "database": {
+      "name": "mydb",
+      "connection_timeout": 30
+    }
+  }
+}

--- a/tests/app.toml
+++ b/tests/app.toml
@@ -1,0 +1,69 @@
+[config]
+PropertyInt8 = 45
+
+[config.Obj1]
+PropertyString = "TestObj1"
+PropertyInt    = 1
+PropertyInt8   = 2
+PropertyInt16  = 3
+PropertyInt64  = 4
+PropertyFloat32 = 1.5
+PropertyFloat64 = 2.75
+PropertyBool   = true
+Time           = "2022-01-19T10:00:00Z"
+ArrayStr       = ["Test", "Test2"]
+ArrayInt       = [1, 2]
+
+[[config.Obj1.ArrayObj]]
+PropertyString = "TestArrObj1"
+PropertyInt    = 1
+PropertyBool   = true
+
+[[config.Obj1.ArrayObj]]
+PropertyString = "TestArrObj2"
+PropertyInt    = 2
+PropertyBool   = false
+
+[[config.Obj1.ArrayObjPtr]]
+PropertyString = "TestArrObj1"
+PropertyInt    = 1
+PropertyBool   = true
+
+[[config.Obj1.ArrayObjPtr]]
+PropertyString = "TestArrObj2"
+PropertyInt    = 2
+PropertyBool   = false
+
+[config.Obj1.MapStr]
+Key1 = "Value1"
+Key2 = "Value2"
+
+[config.Obj1.MapInt]
+1 = "1"
+2 = "2"
+
+[config.Obj1.MapObj.1]
+PropertyString = "TestArrObj1"
+PropertyInt    = 1
+PropertyBool   = true
+
+[config.Obj1.MapObj.2]
+PropertyString = "TestArrObj2"
+PropertyInt    = 2
+PropertyBool   = false
+
+[config.Obj1.MapObj.99]
+PropertyString = "MapObjStrYaml"
+PropertyInt    = 87
+PropertyBool   = true
+
+[config.Obj1.MapObjPtr]
+[config.Obj1.MapObjPtr.false]
+PropertyString = "TestArrObj1"
+PropertyInt    = 1
+PropertyBool   = true
+
+[config.Obj1.MapObjPtr.true]
+PropertyString = "TestArrObj2"
+PropertyInt    = 2
+PropertyBool   = false

--- a/tests/array_syntax_test.go
+++ b/tests/array_syntax_test.go
@@ -1,0 +1,107 @@
+package tests
+
+import (
+	"testing"
+
+	confignet "github.com/maurik77/go-confignet"
+	"github.com/maurik77/go-confignet/extensions"
+	"github.com/maurik77/go-confignet/providers"
+	"github.com/stretchr/testify/assert"
+)
+
+// arrayConfig is a self-contained struct for array syntax tests.
+type arrayConfig struct {
+	Strings  []string
+	Ints     []int
+	Items    []arrayItem
+	ItemsPtr []*arrayItem
+	Fixed    [3]int
+}
+
+type arrayItem struct {
+	Name  string
+	Value int
+}
+
+// TestArraySyntax_Slice_Primitive verifies: Strings__0 = "hello"
+func TestArraySyntax_Slice_Primitive(t *testing.T) {
+	t.Setenv("arr__Strings__0", "hello")
+	t.Setenv("arr__Strings__1", "world")
+
+	conf := buildEnvConf(t)
+	cfg := arrayConfig{}
+	assert.Nil(t, conf.Bind("arr", &cfg))
+
+	assert.Equal(t, "hello", cfg.Strings[0])
+	assert.Equal(t, "world", cfg.Strings[1])
+}
+
+// TestArraySyntax_Slice_Object verifies: Items__0__Name = "first"
+func TestArraySyntax_Slice_Object(t *testing.T) {
+	t.Setenv("arr__Items__0__Name", "first")
+	t.Setenv("arr__Items__0__Value", "10")
+	t.Setenv("arr__Items__1__Name", "second")
+	t.Setenv("arr__Items__1__Value", "20")
+
+	conf := buildEnvConf(t)
+	cfg := arrayConfig{}
+	assert.Nil(t, conf.Bind("arr", &cfg))
+
+	assert.Equal(t, "first", cfg.Items[0].Name)
+	assert.Equal(t, 10, cfg.Items[0].Value)
+	assert.Equal(t, "second", cfg.Items[1].Name)
+	assert.Equal(t, 20, cfg.Items[1].Value)
+}
+
+// TestArraySyntax_Slice_ObjectPtr verifies: ItemsPtr__0__Name = "first" (slice of pointers)
+func TestArraySyntax_Slice_ObjectPtr(t *testing.T) {
+	t.Setenv("arr__ItemsPtr__0__Name", "ptr-first")
+	t.Setenv("arr__ItemsPtr__0__Value", "99")
+
+	conf := buildEnvConf(t)
+	cfg := arrayConfig{}
+	assert.Nil(t, conf.Bind("arr", &cfg))
+
+	assert.Equal(t, "ptr-first", cfg.ItemsPtr[0].Name)
+	assert.Equal(t, 99, cfg.ItemsPtr[0].Value)
+}
+
+// TestArraySyntax_FixedArray_Primitive verifies: Fixed__1 = "42" (fixed-size array)
+func TestArraySyntax_FixedArray_Primitive(t *testing.T) {
+	t.Setenv("arr__Fixed__0", "10")
+	t.Setenv("arr__Fixed__1", "42")
+	t.Setenv("arr__Fixed__2", "30")
+
+	conf := buildEnvConf(t)
+	cfg := arrayConfig{}
+	assert.Nil(t, conf.Bind("arr", &cfg))
+
+	assert.Equal(t, 10, cfg.Fixed[0])
+	assert.Equal(t, 42, cfg.Fixed[1])
+	assert.Equal(t, 30, cfg.Fixed[2])
+}
+
+// TestArraySyntax_JSON verifies the same patterns via JSON (separator: ".")
+func TestArraySyntax_JSON(t *testing.T) {
+	var confBuilder extensions.IConfigurationBuilder = &confignet.ConfigurationBuilder{}
+	confBuilder.Add(&providers.JSONConfigurationProvider{FilePath: "app-array-syntax.json"})
+	conf := confBuilder.Build()
+
+	cfg := arrayConfig{}
+	assert.Nil(t, conf.Bind("arr", &cfg))
+
+	assert.Equal(t, "hello", cfg.Strings[0])
+	assert.Equal(t, "world", cfg.Strings[1])
+	assert.Equal(t, "first", cfg.Items[0].Name)
+	assert.Equal(t, 10, cfg.Items[0].Value)
+	assert.Equal(t, "second", cfg.Items[1].Name)
+	assert.Equal(t, 20, cfg.Items[1].Value)
+	assert.Equal(t, 42, cfg.Fixed[1])
+}
+
+func buildEnvConf(t *testing.T) extensions.IConfiguration {
+	t.Helper()
+	var confBuilder extensions.IConfigurationBuilder = &confignet.ConfigurationBuilder{}
+	confBuilder.Add(&providers.EnvConfigurationProvider{})
+	return confBuilder.Build()
+}

--- a/tests/bind_strict_test.go
+++ b/tests/bind_strict_test.go
@@ -3,9 +3,6 @@ package tests
 import (
 	"testing"
 
-	confignet "github.com/maurik77/go-confignet"
-	"github.com/maurik77/go-confignet/extensions"
-	"github.com/maurik77/go-confignet/providers"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,26 +11,16 @@ import (
 // ---------------------------------------------------------------------------
 
 type strictConfig struct {
-	Host    string
-	Port    int
-	Nested  strictNested
-	Tags    map[string]string
-	Items   []string
+	Host   string
+	Port   int
+	Nested strictNested
+	Tags   map[string]string
+	Items  []string
 }
 
 type strictNested struct {
 	Timeout int
 	Name    string
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-func buildEnvConf() extensions.IConfiguration {
-	var b extensions.IConfigurationBuilder = &confignet.ConfigurationBuilder{}
-	b.Add(&providers.EnvConfigurationProvider{})
-	return b.Build()
 }
 
 // ---------------------------------------------------------------------------
@@ -44,7 +31,7 @@ func TestBindStrict_NoUnknownKeys(t *testing.T) {
 	t.Setenv("app__Host", "localhost")
 	t.Setenv("app__Port", "8080")
 
-	conf := buildEnvConf()
+	conf := buildEnvConf(t)
 	var cfg strictConfig
 	err := conf.BindStrict("app", &cfg)
 	assert.NoError(t, err)
@@ -55,7 +42,7 @@ func TestBindStrict_NoUnknownKeys(t *testing.T) {
 func TestBindStrict_UnknownKey(t *testing.T) {
 	t.Setenv("app__Hsot", "localhost") // typo: Hsot instead of Host
 
-	conf := buildEnvConf()
+	conf := buildEnvConf(t)
 	var cfg strictConfig
 	err := conf.BindStrict("app", &cfg)
 	assert.Error(t, err)
@@ -66,7 +53,7 @@ func TestBindStrict_MultipleUnknownKeys(t *testing.T) {
 	t.Setenv("app__Hsot", "localhost") // typo
 	t.Setenv("app__Prot", "8080")     // typo
 
-	conf := buildEnvConf()
+	conf := buildEnvConf(t)
 	var cfg strictConfig
 	err := conf.BindStrict("app", &cfg)
 	assert.Error(t, err)
@@ -77,7 +64,7 @@ func TestBindStrict_MultipleUnknownKeys(t *testing.T) {
 func TestBindStrict_NestedValidKey(t *testing.T) {
 	t.Setenv("app__Nested__Timeout", "30")
 
-	conf := buildEnvConf()
+	conf := buildEnvConf(t)
 	var cfg strictConfig
 	err := conf.BindStrict("app", &cfg)
 	assert.NoError(t, err)
@@ -87,7 +74,7 @@ func TestBindStrict_NestedValidKey(t *testing.T) {
 func TestBindStrict_NestedUnknownKey(t *testing.T) {
 	t.Setenv("app__Nested__Tiemout", "30") // typo
 
-	conf := buildEnvConf()
+	conf := buildEnvConf(t)
 	var cfg strictConfig
 	err := conf.BindStrict("app", &cfg)
 	assert.Error(t, err)
@@ -97,7 +84,7 @@ func TestBindStrict_NestedUnknownKey(t *testing.T) {
 func TestBindStrict_SliceIndexValid(t *testing.T) {
 	t.Setenv("app__Items__0", "hello")
 
-	conf := buildEnvConf()
+	conf := buildEnvConf(t)
 	var cfg strictConfig
 	err := conf.BindStrict("app", &cfg)
 	assert.NoError(t, err)
@@ -107,7 +94,7 @@ func TestBindStrict_SliceIndexValid(t *testing.T) {
 func TestBindStrict_MapKeyValid(t *testing.T) {
 	t.Setenv("app__Tags__env", "prod")
 
-	conf := buildEnvConf()
+	conf := buildEnvConf(t)
 	var cfg strictConfig
 	err := conf.BindStrict("app", &cfg)
 	assert.NoError(t, err)
@@ -115,14 +102,14 @@ func TestBindStrict_MapKeyValid(t *testing.T) {
 }
 
 func TestBindStrict_NilTarget(t *testing.T) {
-	conf := buildEnvConf()
+	conf := buildEnvConf(t)
 	err := conf.BindStrict("app", nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "nil")
 }
 
 func TestBindStrict_NonPointerTarget(t *testing.T) {
-	conf := buildEnvConf()
+	conf := buildEnvConf(t)
 	var cfg strictConfig
 	err := conf.BindStrict("app", cfg)
 	assert.Error(t, err)

--- a/tests/bind_strict_test.go
+++ b/tests/bind_strict_test.go
@@ -1,0 +1,130 @@
+package tests
+
+import (
+	"testing"
+
+	confignet "github.com/maurik77/go-confignet"
+	"github.com/maurik77/go-confignet/extensions"
+	"github.com/maurik77/go-confignet/providers"
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------------------------------------------------------------------------
+// Test structs
+// ---------------------------------------------------------------------------
+
+type strictConfig struct {
+	Host    string
+	Port    int
+	Nested  strictNested
+	Tags    map[string]string
+	Items   []string
+}
+
+type strictNested struct {
+	Timeout int
+	Name    string
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func buildEnvConf() extensions.IConfiguration {
+	var b extensions.IConfigurationBuilder = &confignet.ConfigurationBuilder{}
+	b.Add(&providers.EnvConfigurationProvider{})
+	return b.Build()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+func TestBindStrict_NoUnknownKeys(t *testing.T) {
+	t.Setenv("app__Host", "localhost")
+	t.Setenv("app__Port", "8080")
+
+	conf := buildEnvConf()
+	var cfg strictConfig
+	err := conf.BindStrict("app", &cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, "localhost", cfg.Host)
+	assert.Equal(t, 8080, cfg.Port)
+}
+
+func TestBindStrict_UnknownKey(t *testing.T) {
+	t.Setenv("app__Hsot", "localhost") // typo: Hsot instead of Host
+
+	conf := buildEnvConf()
+	var cfg strictConfig
+	err := conf.BindStrict("app", &cfg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Hsot")
+}
+
+func TestBindStrict_MultipleUnknownKeys(t *testing.T) {
+	t.Setenv("app__Hsot", "localhost") // typo
+	t.Setenv("app__Prot", "8080")     // typo
+
+	conf := buildEnvConf()
+	var cfg strictConfig
+	err := conf.BindStrict("app", &cfg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Hsot")
+	assert.Contains(t, err.Error(), "Prot")
+}
+
+func TestBindStrict_NestedValidKey(t *testing.T) {
+	t.Setenv("app__Nested__Timeout", "30")
+
+	conf := buildEnvConf()
+	var cfg strictConfig
+	err := conf.BindStrict("app", &cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, 30, cfg.Nested.Timeout)
+}
+
+func TestBindStrict_NestedUnknownKey(t *testing.T) {
+	t.Setenv("app__Nested__Tiemout", "30") // typo
+
+	conf := buildEnvConf()
+	var cfg strictConfig
+	err := conf.BindStrict("app", &cfg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Tiemout")
+}
+
+func TestBindStrict_SliceIndexValid(t *testing.T) {
+	t.Setenv("app__Items__0", "hello")
+
+	conf := buildEnvConf()
+	var cfg strictConfig
+	err := conf.BindStrict("app", &cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, "hello", cfg.Items[0])
+}
+
+func TestBindStrict_MapKeyValid(t *testing.T) {
+	t.Setenv("app__Tags__env", "prod")
+
+	conf := buildEnvConf()
+	var cfg strictConfig
+	err := conf.BindStrict("app", &cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, "prod", cfg.Tags["env"])
+}
+
+func TestBindStrict_NilTarget(t *testing.T) {
+	conf := buildEnvConf()
+	err := conf.BindStrict("app", nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "nil")
+}
+
+func TestBindStrict_NonPointerTarget(t *testing.T) {
+	conf := buildEnvConf()
+	var cfg strictConfig
+	err := conf.BindStrict("app", cfg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "non-pointer")
+}

--- a/tests/confignet_tag_test.go
+++ b/tests/confignet_tag_test.go
@@ -1,0 +1,107 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------------------------------------------------------------------------
+// Test structs
+// ---------------------------------------------------------------------------
+
+type taggedConfig struct {
+	Host    string         `confignet:"host"`
+	Port    int            `confignet:"port"`
+	Debug   bool           `confignet:"debug"`
+	Rate    float64        `confignet:"rate"`
+	DB      taggedDB       `confignet:"database"`
+	Tags    map[string]string
+	Items   []string
+}
+
+type taggedDB struct {
+	Name    string `confignet:"name"`
+	Timeout int    `confignet:"connection_timeout"`
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+
+// ---------------------------------------------------------------------------
+// Tests: basic tag mapping
+// ---------------------------------------------------------------------------
+
+func TestConfignetTag_ScalarFields(t *testing.T) {
+	t.Setenv("svc__host", "example.com")
+	t.Setenv("svc__port", "9090")
+	t.Setenv("svc__debug", "true")
+	t.Setenv("svc__rate", "2.5")
+
+	conf := buildEnvConf(t)
+	var cfg taggedConfig
+	err := conf.Bind("svc", &cfg)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "example.com", cfg.Host)
+	assert.Equal(t, 9090, cfg.Port)
+	assert.Equal(t, true, cfg.Debug)
+	assert.InDelta(t, 2.5, cfg.Rate, 1e-9)
+}
+
+func TestConfignetTag_NestedStruct(t *testing.T) {
+	t.Setenv("svc__database__name", "mydb")
+	t.Setenv("svc__database__connection_timeout", "30")
+
+	conf := buildEnvConf(t)
+	var cfg taggedConfig
+	err := conf.Bind("svc", &cfg)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "mydb", cfg.DB.Name)
+	assert.Equal(t, 30, cfg.DB.Timeout)
+}
+
+func TestConfignetTag_NoTag_FallsBackToFieldName(t *testing.T) {
+	// Tags and Items have no confignet tag — field name is used as-is
+	t.Setenv("svc__Items__0", "hello")
+
+	conf := buildEnvConf(t)
+	var cfg taggedConfig
+	err := conf.Bind("svc", &cfg)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "hello", cfg.Items[0])
+}
+
+func TestConfignetTag_JSONProvider(t *testing.T) {
+	// app-tagged.json uses lowercase keys matching the confignet tags
+	conf := buildJSONConf("app-tagged.json")
+	var cfg taggedConfig
+	err := conf.Bind("service", &cfg)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "db-host", cfg.Host)
+	assert.Equal(t, 5432, cfg.Port)
+	assert.Equal(t, "mydb", cfg.DB.Name)
+	assert.Equal(t, 30, cfg.DB.Timeout)
+}
+
+// ---------------------------------------------------------------------------
+// Tests: tag-aware BindStrict (on this branch strict.go uses tag lookup)
+// ---------------------------------------------------------------------------
+
+func TestConfignetTag_BindStrict_TaggedKeyValid(t *testing.T) {
+	t.Setenv("svc__host", "localhost")
+
+	conf := buildEnvConf(t)
+	var cfg taggedConfig
+
+	// "host" maps to Host via tag — BindStrict must not reject it
+	// (BindStrict is on feature/bind-strict; here we just verify Bind works)
+	err := conf.Bind("svc", &cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, "localhost", cfg.Host)
+}

--- a/tests/coverage_gaps_test.go
+++ b/tests/coverage_gaps_test.go
@@ -1,0 +1,336 @@
+package tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	confignet "github.com/maurik77/go-confignet"
+	"github.com/maurik77/go-confignet/decrypters"
+	"github.com/maurik77/go-confignet/extensions"
+	"github.com/maurik77/go-confignet/internal"
+	"github.com/maurik77/go-confignet/providers"
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func buildJSONConf(filePath string) extensions.IConfiguration {
+	var b extensions.IConfigurationBuilder = &confignet.ConfigurationBuilder{}
+	b.Add(&providers.JSONConfigurationProvider{FilePath: filePath})
+	return b.Build()
+}
+
+// ---------------------------------------------------------------------------
+// InvalidBindError.Error()
+// ---------------------------------------------------------------------------
+
+func TestInvalidBindError_Nil(t *testing.T) {
+	conf := buildJSONConf("app.json")
+	err := conf.Bind("config", nil)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "nil")
+}
+
+func TestInvalidBindError_NonPointer(t *testing.T) {
+	conf := buildJSONConf("app.json")
+	var cfg myConfig
+	err := conf.Bind("config", cfg) // not a pointer
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "non-pointer")
+}
+
+func TestInvalidBindError_NilPointer(t *testing.T) {
+	conf := buildJSONConf("app.json")
+	var cfg *myConfig // nil pointer
+	err := conf.Bind("config", cfg)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "nil")
+}
+
+// ---------------------------------------------------------------------------
+// Configuration.GetProviders()
+// ---------------------------------------------------------------------------
+
+func TestConfiguration_GetProviders(t *testing.T) {
+	p1 := &providers.JSONConfigurationProvider{FilePath: "app.json"}
+	p2 := &providers.YamlConfigurationProvider{FilePath: "app.yaml"}
+
+	var b extensions.IConfigurationBuilder = &confignet.ConfigurationBuilder{}
+	b.Add(p1)
+	b.Add(p2)
+	conf := b.Build()
+
+	infos := conf.GetProviders()
+	assert.Len(t, infos, 2)
+	assert.Equal(t, p1, infos[0].Provider)
+	assert.Equal(t, p2, infos[1].Provider)
+}
+
+// ---------------------------------------------------------------------------
+// ChainedConfigurationProvider.AddWithEncrypter() & GetDataMultiValues()
+// ---------------------------------------------------------------------------
+
+func TestChainedConfigurationProvider_AddWithEncrypter(t *testing.T) {
+	// Verify AddWithEncrypter registers the provider+decrypter without panicking.
+	// We don't call Load here because the Shamir data is not AES-encrypted.
+	chained := &confignet.ChainedConfigurationProvider{}
+	dec := &decrypters.AesConfigurationDecrypter{Secret: "mysecret"}
+	chained.AddWithEncrypter(&providers.JSONConfigurationProvider{FilePath: "app.json"}, dec)
+
+	// GetProviders is not on ChainedConfigurationProvider, but GetData returns empty before Load
+	data := chained.GetData()
+	assert.Nil(t, data) // not loaded yet
+}
+
+func TestChainedConfigurationProvider_GetDataMultiValues(t *testing.T) {
+	chained := &confignet.ChainedConfigurationProvider{}
+	chained.Add(&providers.JSONConfigurationProvider{FilePath: "shamir/copy-shamir-2.json"})
+	chained.Add(&providers.YamlConfigurationProvider{FilePath: "shamir/copy-shamir-3.yaml"})
+
+	chained.Load(nil)
+
+	multiValues := chained.GetDataMultiValues()
+	assert.NotNil(t, multiValues)
+
+	// Both files have the same key, so at least one key should have 2 values
+	found := false
+	for _, vals := range multiValues {
+		if len(vals) == 2 {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected at least one key with 2 values from two shamir providers")
+}
+
+// ---------------------------------------------------------------------------
+// BuildOrPanic()
+// ---------------------------------------------------------------------------
+
+func TestBuildOrPanic_Success(t *testing.T) {
+	b := &confignet.ConfigurationBuilder{}
+	b.Add(&providers.JSONConfigurationProvider{FilePath: "app.json"})
+
+	assert.NotPanics(t, func() {
+		conf := b.BuildOrPanic()
+		assert.NotNil(t, conf)
+	})
+}
+
+func TestBuildOrPanic_PanicsOnMissingFile(t *testing.T) {
+	b := &confignet.ConfigurationBuilder{}
+	b.Add(&providers.JSONConfigurationProvider{FilePath: "nonexistent-file-xyz.json"})
+
+	assert.Panics(t, func() {
+		b.BuildOrPanic()
+	})
+}
+
+// ---------------------------------------------------------------------------
+// SetLogger()
+// ---------------------------------------------------------------------------
+
+type captureLogger struct {
+	messages []string
+}
+
+func (l *captureLogger) Printf(format string, args ...interface{}) {
+	l.messages = append(l.messages, fmt.Sprintf(format, args...))
+}
+
+func TestSetLogger_CustomLogger(t *testing.T) {
+	cl := &captureLogger{}
+	confignet.SetLogger(cl)
+
+	b := &confignet.ConfigurationBuilder{}
+	b.Add(&providers.JSONConfigurationProvider{FilePath: "app.json"})
+	_ = b.Build()
+
+	// Builder logs at least one message when adding a provider
+	assert.Greater(t, len(cl.messages), 0, "expected logger to receive messages")
+
+	// Restore default logger (stdLogger is unexported, so we use a safe fallback)
+	confignet.SetLogger(&captureLogger{}) // keep a non-nil logger
+}
+
+func TestSetLogger_NilIsIgnored(t *testing.T) {
+	assert.NotPanics(t, func() {
+		confignet.SetLogger(nil)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// AES encryption round-trip
+// ---------------------------------------------------------------------------
+
+func TestAES_EncryptDecryptRoundTrip(t *testing.T) {
+	secret := "mysupersecretkey"
+	plaintext := []byte("hello, world!")
+
+	encrypted, err := internal.EncryptBytesToBase64(plaintext, secret)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, encrypted)
+
+	decrypted, err := internal.DecryptBase64ToBytes(encrypted, secret)
+	assert.NoError(t, err)
+	assert.Equal(t, plaintext, decrypted)
+}
+
+func TestAES_EncryptDecryptRoundTrip_LongText(t *testing.T) {
+	secret := "anothersecret"
+	plaintext := []byte("a longer text that exceeds the AES block size boundary definitely yes it does")
+
+	encrypted, err := internal.EncryptBytesToBase64(plaintext, secret)
+	assert.NoError(t, err)
+
+	decrypted, err := internal.DecryptBase64ToBytes(encrypted, secret)
+	assert.NoError(t, err)
+	assert.Equal(t, plaintext, decrypted)
+}
+
+func TestAES_DecryptBadBase64(t *testing.T) {
+	_, err := internal.DecryptBase64ToBytes("!!!notbase64!!!", "secret")
+	assert.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// internal.MarshalToFile() / UnmarshalFromFile()
+// ---------------------------------------------------------------------------
+
+type marshalPayload struct {
+	Name  string `json:"name"`
+	Value int    `json:"value"`
+}
+
+func TestMarshalToFile_RoundTrip(t *testing.T) {
+	src := marshalPayload{Name: "test", Value: 42}
+	path := filepath.Join(t.TempDir(), "output.json")
+
+	err := internal.MarshalToFile(path, src, json.Marshal)
+	assert.NoError(t, err)
+
+	var got marshalPayload
+	err = internal.UnmarshalFromFile(path, &got, json.Unmarshal)
+	assert.NoError(t, err)
+	assert.Equal(t, src.Name, got.Name)
+	assert.Equal(t, src.Value, got.Value)
+}
+
+func TestUnmarshalFromFile_NotFound(t *testing.T) {
+	var dummy map[string]interface{}
+	err := internal.UnmarshalFromFile("no-such-file.json", &dummy, json.Unmarshal)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// ---------------------------------------------------------------------------
+// AesConfigurationDecrypter.Init() — path with ConfigFilePath set
+// ---------------------------------------------------------------------------
+
+func TestAesDecrypter_InitWithConfigFile(t *testing.T) {
+	// AesConfigurationDecrypter.Init reads a settings file (meta-config) via
+	// ConfigureConfigurationProviders, then calls GetValue(SecretConfigPath).
+	// We need:
+	//   1. A data file holding the actual secret value.
+	//   2. A settings file pointing to that data file as a provider.
+
+	tmpDir := t.TempDir()
+
+	// Step 1: data file with the secret
+	dataFile := filepath.Join(tmpDir, "data.json")
+	err := os.WriteFile(dataFile, []byte(`{"mysecretpath": "mysecret"}`), 0600)
+	assert.NoError(t, err)
+
+	// Step 2: settings file referencing the data file
+	settingsContent := fmt.Sprintf(`{"providers":[{"name":"json","properties":{"filePath":%q}}]}`, dataFile)
+	settingsFile := filepath.Join(tmpDir, "settings.json")
+	err = os.WriteFile(settingsFile, []byte(settingsContent), 0600)
+	assert.NoError(t, err)
+
+	dec := &decrypters.AesConfigurationDecrypter{
+		ConfigFileType:   "json",
+		ConfigFilePath:   settingsFile,
+		SecretConfigPath: "mysecretpath",
+	}
+
+	dec.Init(&confignet.ConfigurationBuilder{})
+	assert.Equal(t, "mysecret", dec.Secret)
+}
+
+// ---------------------------------------------------------------------------
+// Binder error paths
+// ---------------------------------------------------------------------------
+
+func TestBinder_InvalidIntValue(t *testing.T) {
+	t.Setenv("config__Obj1__PropertyInt", "notanint")
+
+	var b extensions.IConfigurationBuilder = &confignet.ConfigurationBuilder{}
+	b.Add(&providers.EnvConfigurationProvider{})
+	conf := b.Build()
+
+	cfg := myConfig{Obj1: &subObj{}}
+	err := conf.Bind("config", &cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, cfg.Obj1.PropertyInt) // parse failed, keeps zero
+}
+
+func TestBinder_InvalidBoolValue(t *testing.T) {
+	t.Setenv("config__Obj1__PropertyBool", "notabool")
+
+	var b extensions.IConfigurationBuilder = &confignet.ConfigurationBuilder{}
+	b.Add(&providers.EnvConfigurationProvider{})
+	conf := b.Build()
+
+	cfg := myConfig{Obj1: &subObj{}}
+	err := conf.Bind("config", &cfg)
+	assert.NoError(t, err)
+	assert.False(t, cfg.Obj1.PropertyBool)
+}
+
+func TestBinder_InvalidFloatValue(t *testing.T) {
+	t.Setenv("config__Obj1__PropertyFloat32", "notafloat")
+
+	var b extensions.IConfigurationBuilder = &confignet.ConfigurationBuilder{}
+	b.Add(&providers.EnvConfigurationProvider{})
+	conf := b.Build()
+
+	cfg := myConfig{Obj1: &subObj{}}
+	err := conf.Bind("config", &cfg)
+	assert.NoError(t, err)
+	var expected float32
+	assert.Equal(t, expected, cfg.Obj1.PropertyFloat32)
+}
+
+func TestBinder_InvalidTimeValue(t *testing.T) {
+	t.Setenv("config__Obj1__Time", "not-a-time")
+
+	var b extensions.IConfigurationBuilder = &confignet.ConfigurationBuilder{}
+	b.Add(&providers.EnvConfigurationProvider{})
+	conf := b.Build()
+
+	cfg := myConfig{Obj1: &subObj{}}
+	err := conf.Bind("config", &cfg)
+	assert.NoError(t, err)
+	assert.True(t, cfg.Obj1.Time.IsZero())
+}
+
+func TestBinder_ArrayOutOfRange(t *testing.T) {
+	// ArrayInt is *[3]int — index 99 is out of range, should not panic
+	t.Setenv("config__Obj1__ArrayInt__99", "42")
+
+	var b extensions.IConfigurationBuilder = &confignet.ConfigurationBuilder{}
+	b.Add(&providers.JSONConfigurationProvider{FilePath: "app.json"})
+	b.Add(&providers.EnvConfigurationProvider{})
+	conf := b.Build()
+
+	cfg := myConfig{}
+	err := conf.Bind("config", &cfg)
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg.Obj1)
+	assert.NotNil(t, cfg.Obj1.ArrayInt)
+}

--- a/tests/default_tag_test.go
+++ b/tests/default_tag_test.go
@@ -1,0 +1,125 @@
+package tests
+
+import (
+	"testing"
+
+	confignet "github.com/maurik77/go-confignet"
+	"github.com/maurik77/go-confignet/extensions"
+	"github.com/maurik77/go-confignet/providers"
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------------------------------------------------------------------------
+// Test structs
+// ---------------------------------------------------------------------------
+
+type defaultConfig struct {
+	Port    int     `default:"8080"`
+	Host    string  `default:"localhost"`
+	Debug   bool    `default:"true"`
+	Rate    float64 `default:"1.5"`
+	Nested  defaultNested
+	PtrSub  *defaultNested
+}
+
+type defaultNested struct {
+	Timeout int    `default:"30"`
+	Name    string `default:"worker"`
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func buildEmptyConf() extensions.IConfiguration {
+	// EnvConfigurationProvider with a prefix that will never match anything,
+	// so the provider supplies no keys — defaults must fill the gaps.
+	var b extensions.IConfigurationBuilder = &confignet.ConfigurationBuilder{}
+	b.Add(&providers.EnvConfigurationProvider{Prefix: "zzznomatch__"})
+	return b.Build()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+func TestDefaultTag_AppliedWhenMissing(t *testing.T) {
+	conf := buildEmptyConf()
+	var cfg defaultConfig
+	err := conf.Bind("defaults", &cfg)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 8080, cfg.Port)
+	assert.Equal(t, "localhost", cfg.Host)
+	assert.Equal(t, true, cfg.Debug)
+	assert.InDelta(t, 1.5, cfg.Rate, 1e-9)
+}
+
+func TestDefaultTag_NestedStruct(t *testing.T) {
+	conf := buildEmptyConf()
+	var cfg defaultConfig
+	err := conf.Bind("defaults", &cfg)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 30, cfg.Nested.Timeout)
+	assert.Equal(t, "worker", cfg.Nested.Name)
+}
+
+func TestDefaultTag_OverriddenByProvider(t *testing.T) {
+	// The JSON file has defaults__Port = 9090 and defaults__Host = "example.com"
+	t.Setenv("defaults__Port", "9090")
+	t.Setenv("defaults__Host", "example.com")
+
+	var b extensions.IConfigurationBuilder = &confignet.ConfigurationBuilder{}
+	b.Add(&providers.EnvConfigurationProvider{})
+	conf := b.Build()
+
+	var cfg defaultConfig
+	err := conf.Bind("defaults", &cfg)
+	assert.NoError(t, err)
+
+	// Provider values win over tag defaults
+	assert.Equal(t, 9090, cfg.Port)
+	assert.Equal(t, "example.com", cfg.Host)
+	// Fields not set by provider still get their defaults
+	assert.Equal(t, true, cfg.Debug)
+	assert.InDelta(t, 1.5, cfg.Rate, 1e-9)
+}
+
+func TestDefaultTag_ProviderExplicitZeroOverridesDefault(t *testing.T) {
+	// Provider explicitly sets Port to 0 — this should win over the default.
+	t.Setenv("defaults__Port", "0")
+
+	var b extensions.IConfigurationBuilder = &confignet.ConfigurationBuilder{}
+	b.Add(&providers.EnvConfigurationProvider{})
+	conf := b.Build()
+
+	var cfg defaultConfig
+	err := conf.Bind("defaults", &cfg)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 0, cfg.Port)
+}
+
+func TestDefaultTag_NoDefaultTag_KeepsZero(t *testing.T) {
+	// A struct without default tags should still have zero values when no provider matches.
+	conf := buildEmptyConf()
+	var cfg struct {
+		Port int
+		Host string
+	}
+	err := conf.Bind("notag", &cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, cfg.Port)
+	assert.Equal(t, "", cfg.Host)
+}
+
+func TestDefaultTag_PtrSubStruct_NilStaysNil(t *testing.T) {
+	// PtrSub is a *defaultNested — when no provider sets any of its fields,
+	// it should remain nil (we don't allocate just to apply defaults).
+	conf := buildEmptyConf()
+	var cfg defaultConfig
+	err := conf.Bind("defaults", &cfg)
+	assert.NoError(t, err)
+	assert.Nil(t, cfg.PtrSub)
+}

--- a/tests/settings-toml.json
+++ b/tests/settings-toml.json
@@ -1,0 +1,10 @@
+{
+  "providers": [
+    {
+      "name": "toml",
+      "properties": {
+        "filePath": "app.toml"
+      }
+    }
+  ]
+}

--- a/tests/toml_test.go
+++ b/tests/toml_test.go
@@ -1,0 +1,67 @@
+package tests
+
+import (
+	"testing"
+
+	confignet "github.com/maurik77/go-confignet"
+	"github.com/maurik77/go-confignet/extensions"
+	"github.com/maurik77/go-confignet/providers"
+	"github.com/stretchr/testify/assert"
+)
+
+func buildTomlConf(filePath string) extensions.IConfiguration {
+	var confBuilder extensions.IConfigurationBuilder = &confignet.ConfigurationBuilder{}
+	confBuilder.Add(&providers.TomlConfigurationProvider{FilePath: filePath})
+	return confBuilder.Build()
+}
+
+func TestTomlProvider_Bind(t *testing.T) {
+	conf := buildTomlConf("app.toml")
+
+	myCfg := myConfig{}
+	err := conf.Bind("config", &myCfg)
+	assert.Nil(t, err)
+
+	validateObject(t, getJSONExpectedValue(), myCfg)
+}
+
+func TestTomlProvider_BindSubSection(t *testing.T) {
+	conf := buildTomlConf("app.toml")
+
+	subObjConf := subObj{}
+	err := conf.Bind("config/Obj1", &subObjConf)
+	assert.Nil(t, err)
+
+	validateSubObject(t, *getJSONExpectedValue().Obj1, subObjConf)
+}
+
+func TestTomlProvider_GetValue(t *testing.T) {
+	conf := buildTomlConf("app.toml")
+
+	assert.Equal(t, "TestObj1", conf.GetValue("config/Obj1/PropertyString"))
+	assert.Equal(t, "45", conf.GetValue("config/PropertyInt8"))
+	assert.Equal(t, "true", conf.GetValue("config/Obj1/PropertyBool"))
+	assert.Equal(t, "1.5", conf.GetValue("config/Obj1/PropertyFloat32"))
+}
+
+func TestTomlProvider_MissingFile(t *testing.T) {
+	conf := buildTomlConf("nonexistent.toml")
+
+	cfg := myConfig{}
+	err := conf.Bind("config", &cfg)
+	// Bind itself does not error on missing file; the provider logs and returns empty data
+	assert.Nil(t, err)
+	assert.Nil(t, cfg.Obj1)
+}
+
+func TestTomlProvider_MetaConfig(t *testing.T) {
+	var confBuilder extensions.IConfigurationBuilder = &confignet.ConfigurationBuilder{}
+	confBuilder.ConfigureConfigurationProviders(confignet.ConfigFileTypeJSON, "settings-toml.json")
+	conf := confBuilder.Build()
+
+	myCfg := myConfig{}
+	err := conf.Bind("config", &myCfg)
+	assert.Nil(t, err)
+	assert.NotNil(t, myCfg.Obj1)
+	assert.Equal(t, "TestObj1", myCfg.Obj1.PropertyString)
+}


### PR DESCRIPTION
# Release Notes — develop → main

## New Features

### TOML Configuration Provider
Added `providers.TomlConfigurationProvider` backed by `github.com/BurntSushi/toml`.
TOML files work with all existing features (sections, nested structs, slices, maps, AES/Shamir decryption) and are registered as a built-in source (`"toml"`) so they can be declared in `settings.json`/`settings.yaml` like any other provider.

```go
builder.Add(&providers.TomlConfigurationProvider{
    Settings: extensions.ProviderSettings{ConfigFilePath: "app.toml"},
})
```

Separator: `.` (same as JSON and YAML).

---

### `confignet` Struct Tag — flexible key-to-field mapping
Fields can now declare the config key name they map to, independent of the Go field name.
This enables natural naming in config files (e.g. `snake_case` or `kebab-case`) while keeping idiomatic `PascalCase` Go fields.

```go
type DB struct {
    Name    string `confignet:"name"`
    Timeout int    `confignet:"connection_timeout"`
}
```

A field without a `confignet` tag continues to match by its Go field name (fully backward compatible).
Tag lookup is cached per type in a `sync.Map` so the reflection cost is paid only once.

---

### `default` Struct Tag — zero-value field defaults
Fields can declare a fallback value that is applied **before** any provider is read.
Provider-supplied values (including an explicit `"0"` or `"false"`) always win.

```go
type Config struct {
    Host    string `default:"localhost"`
    Port    int    `default:"8080"`
    Timeout int    `default:"30"`
}
```

Defaults are applied recursively to nested structs. Pointer fields that are `nil` at bind time are left untouched (no allocation).

---

### `BindStrict()` — detect unknown configuration keys
`Configuration.BindStrict(section, &cfg)` behaves like `Bind()` but returns an error listing every configuration key that matched the section prefix yet resolved to no struct field.

```go
err := conf.BindStrict("app", &cfg)
// confignet: unknown configuration keys: Hsot, Prot
```

Useful for catching typos in environment variables or config files early.
`IsValidPath()` is tag-aware: keys that match via `confignet` tags are accepted.

---

### `BuildOrPanic()` — strict configuration loading
`ConfigurationBuilder.BuildOrPanic()` wraps `Build()` with an error-collecting logger. If any provider logs a load error (e.g. missing file, bad credentials), the method panics with all collected messages. Use it when a misconfigured environment should be a fatal startup error.

---

### Custom Logger
`confignet.SetLogger(l)` routes all internal log output to any type implementing the minimal `extensions.Logger` interface (`Printf(format string, args ...interface{})`). Cascades to the `internal` and `providers` packages. Passing `nil` is a no-op.

---

## Improvements

### Azure Key Vault SDK upgrade
Updated from the legacy `sdk/keyvault/azsecrets v0.4.0` (pre-GA) to the stable `sdk/security/keyvault/azsecrets v1.4.0`.
All transitive Azure SDK dependencies (`azcore`, `azidentity`, `azure-sdk-for-go/sdk/internal`) updated to their latest stable versions.

### Go version upgrade
`go.mod` minimum version raised from `1.17` to `1.24.0`.
GitHub Actions workflow now derives the Go version from `go.mod` automatically (`go-version-file: go.mod`).

### `float32` / `float64` support
The configuration binder now handles `float32` and `float64` fields in addition to integer types.

### JSON / YAML array bracket-index syntax
Array elements can now be specified with bracket notation (e.g. `section[0]`) in addition to the existing double-underscore notation (`section__0`).

---

## Documentation
- `README.md` fully overhauled: comprehensive examples, separators table, struct tags section, strict binding section, TOML provider entry, meta-config provider name table updated.
- `CLAUDE.md` architecture section updated to document new internal files and behaviors.

---

## Dependencies

| Dependency | Before | After |
|---|---|---|
| `github.com/BurntSushi/toml` | — | v1.6.0 (**new**) |
| `github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets` | — | v1.4.0 (**replaced** `sdk/keyvault/azsecrets`) |
| `github.com/Azure/azure-sdk-for-go/sdk/azcore` | v0.21.0 | v1.21.0 |
| `github.com/Azure/azure-sdk-for-go/sdk/azidentity` | v0.13.0 | v1.13.1 |
| `github.com/AzureAD/microsoft-authentication-library-for-go` | v0.4.0 | v1.6.0 |
| `github.com/golang-jwt/jwt` | v3.2.1 | v5.3.0 (`/v5` module path) |
| `github.com/google/uuid` | v1.1.1 | v1.6.0 |
| `github.com/stretchr/testify` | v1.8.2 | v1.11.1 |
| `golang.org/x/crypto` | v0.0.0-20201016 | v0.47.0 |
| `golang.org/x/sys` | v0.0.0-20211019 | v0.40.0 |
| `golang.org/x/net` | v0.0.0-20220114 | v0.49.0 |
| `golang.org/x/text` | v0.3.7 | v0.33.0 |
| Go minimum version | 1.17 | 1.24.0 |
